### PR TITLE
Flammen's Big Alchemy Update

### DIFF
--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -189,7 +189,7 @@
 	icon_state = null
 
 /obj/item/roguegem/random/Initialize()
-	var/newgem = list(/obj/item/roguegem = 5, /obj/item/roguegem/green = 15, /obj/item/roguegem/blue = 10, /obj/item/roguegem/yellow = 20, /obj/item/roguegem/violet = 10, /obj/item/roguegem/diamond = 5, /obj/item/riddleofsteel = 1, /obj/item/rogueore/silver = 3)
+	var/newgem = list(/obj/item/roguegem/red = 10, /obj/item/roguegem/green = 25, /obj/item/roguegem/blue = 15, /obj/item/roguegem/yellow = 30, /obj/item/roguegem/violet = 20, /obj/item/roguegem/diamond = 5, /obj/item/riddleofsteel = 1, /obj/item/rogueore/silver = 3)
 	var/pickgem = pickweight(newgem)
 	new pickgem(get_turf(src))
 	qdel(src)

--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -1,9 +1,35 @@
 
 /obj/item/roguegem
+	name = "alchemical glass"
+	icon_state = "ruby_cut"
+	icon = 'icons/roguetown/items/gems.dmi'
+	desc = "Its facets shine so brightly, but it's nothing more than mineral glass, produced by suffusing mere stone with arcyne sublimate. Its ability to shift hues when exposed to manna makes it perfect for stained glass!"
+	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
+	w_class = WEIGHT_CLASS_TINY
+	slot_flags = ITEM_SLOT_MOUTH
+	dropshrink = 0.4
+	drop_sound = 'sound/items/gem.ogg'
+	sellprice = 10
+	static_price = FALSE
+	mill_result = /obj/item/reagent_containers/powder/crystalglass
+
+/obj/item/reagent_containers/powder/crystalglass
+	name = "crystal dust"
+	desc = ""
+	gender = PLURAL
+	icon = 'icons/roguetown/items/gems.dmi'
+	icon_state = "rontz_dust"
+	volume = 5
+	list_reagents = list(/datum/reagent/gemdust = 5)
+	grind_results = list(/datum/reagent/gemdust = 5)
+	sellprice = 5
+
+/obj/item/roguegem/red
 	name = "ruby"
 	icon_state = "ruby_cut"
 	icon = 'icons/roguetown/items/gems.dmi'
-	desc = "Its facets shine so brightly.."
+	desc = "Its facets shine so brightly... What a gorgeous gem!"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
@@ -41,7 +67,7 @@
 /datum/reagent/gemdust
 	name = "Gemstone Dust"
 	description = "Glassy."
-	color = "#d7d0be" 
+	color = "#d7d0be"
 	overdose_threshold = 0
 	metabolization_rate = 1
 
@@ -86,14 +112,14 @@
 	sellprice = 33
 
 /obj/item/roguegem/blue
-	name = "quartz"
+	name = "turquoise"
 	icon_state = "quartz_cut"
 	sellprice = 88
 	desc = "Pale blue, like a frozen tear." // i am not sure if this is really quartz.
 	mill_result = /obj/item/reagent_containers/powder/blortz
 
 /obj/item/reagent_containers/powder/blortz
-	name = "quartz dust"
+	name = "turquoise dust"
 	desc = ""
 	gender = PLURAL
 	icon = 'icons/roguetown/items/gems.dmi'
@@ -200,12 +226,12 @@
 /datum/reagent/mfire
 	name = "Malum's Fire"
 	description = "Divine Burning."
-	color = "#ffc229" 
+	color = "#ffc229"
 	overdose_threshold = 0
 	metabolization_rate = 0.5
 
 /datum/reagent/mfire/on_mob_life(mob/living/carbon/M)
-	if(HAS_TRAIT(M, TRAIT_MALUMSGRACE)) 
+	if(HAS_TRAIT(M, TRAIT_MALUMSGRACE))
 		M.apply_status_effect(/datum/status_effect/buff/mfire)
 		if(holder.has_reagent(/datum/reagent/mfire))
 			holder.remove_reagent(/datum/reagent/mfire, 15)

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mudcrab.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mudcrab.dm
@@ -1,7 +1,7 @@
 //Look Sir, free crabs!
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab
-	name = "bogcrab"
-	desc = ""
+	name = "mudcrab"
+	desc = "An omnivorous aquatic arthropod the size of a small dog, commonly found wherever bodies of water meet bodies of soil. Although mudcrabs can't be tamed, farmers and druids sometimes keep them in their gardens to clean up discarded foodstuffs when their composters are full. Their droppings happen to be useful for making fertilizer."
 	icon_state = "mudcrab"
 	icon_living = "mudcrab"
 	icon_dead = "mudcrab_dead"
@@ -12,6 +12,7 @@
 	turns_per_move = 5
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/rawcrab = 4, /obj/item/natural/carapace = 2)
 	faction = list("crabs")
+	food_type = list(/obj/item/reagent_containers/food/snacks)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -20,16 +20,22 @@
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/ozium
-	name = "Ozium"
-	result = list(/obj/item/reagent_containers/powder/ozium)
-	reqs = list(/obj/item/ash = 2, /datum/reagent/berrypoison = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 2)
+	name = "Ozium Poppy"
+	result = list(/obj/item/reagent_containers/food/snacks/grown/poppy)
+	reqs = list(/obj/item/ash = 1, /obj/item/reagent_containers/food/snacks/grown/berries/rogue = 1, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 1)
 	craftdiff = 2
 
-/datum/crafting_recipe/roguetown/alchemy/moon
-	name = "Moondust"
-	result = list(/obj/item/reagent_containers/powder/moondust)
-	reqs = list(/obj/item/ash = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 2, /datum/reagent/berrypoison = 2)
-	craftdiff = 2
+/datum/crafting_recipe/roguetown/alchemy/puremoon
+	name = "Purest Moondust"
+	result = list(/obj/item/reagent_containers/powder/moondust/purest)
+	reqs = list(/obj/item/reagent_containers/powder/moondust, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 1, /datum/reagent/berrypoison = 5)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/spice
+	name = "Spice Melange"
+	result = list(/obj/item/reagent_containers/powder/spice)
+	reqs = list(/obj/item/ash = 1, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 1, /datum/reagent/berrypoison = 5)
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/salt
 	name = "Salt Pile"
@@ -64,8 +70,8 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1,
-		/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 1,
-		/obj/item/natural/worms/leech = 1)
+		/obj/item/reagent_containers/food/snacks/grown/herbs = 2,
+		/obj/item/ash = 1)
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/alchemy/minorhealthpot3x
@@ -73,8 +79,8 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot,/obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot,/obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 3,
-		/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 2,
-		/obj/item/natural/worms/leech = 2)
+		/obj/item/reagent_containers/food/snacks/grown/herbs = 2,
+		/obj/item/ash = 2)
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/alchemy/healthpot
@@ -83,7 +89,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1,
 		/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 1,
-		/obj/item/reagent_containers/food/snacks/fish = 1)
+		/obj/item/ash = 1)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/healthpot3x
@@ -92,7 +98,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 3,
 		/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 2,
-		/obj/item/reagent_containers/food/snacks/fish = 2)
+		/obj/item/ash = 2)
 	craftdiff = 2
 
 //fuck fish
@@ -109,22 +115,43 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1,
-		/obj/item/reagent_containers/powder/sublimate = 1,
-		/obj/item/reagent_containers/food/snacks/grown/apple = 2,
-		/obj/item/reagent_containers/food/snacks/fish/clownfish = 1,
-		/obj/item/natural/bone = 2)
-	craftdiff = 5
+		/obj/item/reagent_containers/food/snacks/grown/apple = 1,
+		/obj/item/ash = 1,
+		/obj/item/natural/bone = 1)
+	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/alchemy/majorhealthpot3x
 	name = "3x Major Health Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot,/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot,/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 3,
-		/obj/item/reagent_containers/powder/sublimate = 2,
-		/obj/item/reagent_containers/food/snacks/grown/apple = 4,
-		/obj/item/reagent_containers/food/snacks/fish/clownfish = 2,
-		/obj/item/natural/bone = 4)
+		/obj/item/reagent_containers/food/snacks/grown/apple = 2,
+		/obj/item/ash = 2,
+		/obj/item/natural/bone = 2)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/alchemy/sublimeambrosia
+	name = "Sublime Ambrosia Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/datum/reagent/medicine/minorhealthpot = 45,
+		/datum/reagent/medicine/healthpot = 45,
+		/datum/reagent/medicine/majorhealthpot = 45,
+		/obj/item/ash = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1)
 	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/alchemy/sublimeambrosia3x
+	name = "3x Sublime Ambrosia Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia, /obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia, /obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/datum/reagent/medicine/minorhealthpot = 15,
+		/datum/reagent/medicine/healthpot = 15,
+		/datum/reagent/medicine/majorhealthpot = 15,
+		/obj/item/reagent_containers/powder/mfire = 1)
+	craftdiff = 6
 
 /datum/crafting_recipe/roguetown/alchemy/antipoison_pot
 	name = "Anti Poison Potion"
@@ -140,7 +167,7 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot,/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot,/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 3,
-		/obj/item/reagent_containers/powder/sublimate = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
 		/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 2)
 	craftdiff = 1
 
@@ -153,7 +180,7 @@
 /datum/crafting_recipe/roguetown/alchemy/antipreg_pot_3x
 	name = "3x Anti Pregnancy Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/antipregnancy,/obj/item/reagent_containers/glass/bottle/rogue/antipregnancy,/obj/item/reagent_containers/glass/bottle/rogue/antipregnancy)
-	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 2)
+	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 2, /obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 2)
 	craftdiff = 1
 
 /// bottle craft
@@ -218,22 +245,42 @@
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 2)
 	craftdiff = 3
 
+/datum/crafting_recipe/roguetown/alchemy/poisonberry
+	name = "corrupt berry"
+	result = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 1)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue = 1, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/safeberry
+	name = "purify berry"
+	result = list(/obj/item/reagent_containers/food/snacks/grown/rogue = 1)
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 1, /obj/item/reagent_containers/food/snacks/grown/herbs = 1)
+	craftdiff = 3
+
 /datum/crafting_recipe/roguetown/alchemy/w2coa
 	name = "transmute small log to coal"
 	result = list(/obj/item/rogueore/coal = 1)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	craftdiff = 0
+	subtype_reqs = TRUE
 
 /datum/crafting_recipe/roguetown/alchemy/l2coa
 	name = "transmute log to coal"
 	result = list(/obj/item/rogueore/coal = 4)
 	reqs = list(/obj/item/grown/log/tree = 1)
 	craftdiff = 1
+	subtype_reqs = TRUE
 
 /datum/crafting_recipe/roguetown/alchemy/s2coa
 	name = "transmute stone to coal"
 	result = list(/obj/item/rogueore/coal = 1)
 	reqs = list(/obj/item/natural/stone = 4)
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/alchemy/coa2s
+	name = "transmute coal to stones"
+	result = list(/obj/item/natural/stone = 4)
+	reqs = list(/obj/item/rogueore/coal = 1)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/c2irn
@@ -249,19 +296,26 @@
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/alchemy/i2top // Keep topers and their trinkets cheap to prevent wealth creep. Cheap means of getting gem dust, for potions.
-	name = "transmute iron to topaz"
+	name = "transmute iron to toper"
 	result = list(/obj/item/roguegem/yellow = 1)
 	reqs = list(
-		/obj/item/rogueore/iron = 1,
+		/obj/item/rogueore/iron = 1, //Toper will be worth 30 mammon. Iron ingot is worth 25.
 		/obj/item/natural/stone = 1)
 	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/alchemy/alglass // TO-DO: add construction recipe for church windows using this. Touching a church window with mage hand will invert it to the evil version and vice versa.
+	name = "transmute stone to alchemical glass"
+	result = list(/obj/item/roguegem = 1)
+	reqs = list(
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/natural/stone = 1)
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/t2gem
 	name = "transmute topaz to emerald"
 	result = list(/obj/item/roguegem/green = 1)
 	reqs = list(
-		/obj/item/roguegem/yellow = 1,
-		/obj/item/rogueore/gold = 2)
+		/obj/item/roguegem/yellow = 2)
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/alchemy/g2saf
@@ -269,37 +323,45 @@
 	result = list(/obj/item/roguegem/violet = 1)
 	reqs = list(
 		/obj/item/roguegem/green = 1,
-		/obj/item/rogueore/gold = 2)
+		/obj/item/roguegem/yellow = 1)
 	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/alchemy/s2blo
-	name = "transmute sapphire to quartz"
+	name = "transmute sapphire to turquise"
 	result = list(/obj/item/roguegem/blue = 1)
 	reqs = list(
 		/obj/item/roguegem/violet = 1,
-		/obj/item/rogueore/gold = 2)
+		/obj/item/roguegem/yellow = 1)
 	craftdiff = 4
 
+/datum/crafting_recipe/roguetown/alchemy/b2ron
+	name = "transmute turquoise to ruby"
+	result = list(/obj/item/roguegem/red = 1)
+	reqs = list(
+		/obj/item/roguegem/blue = 1,
+		/obj/item/roguegem/yellow = 1)
+	craftdiff = 5
+
 /datum/crafting_recipe/roguetown/alchemy/r2dia
-	name = "transmute quartz to diamond"
+	name = "transmute ruby to iamond"
 	result = list(/obj/item/roguegem/diamond = 1)
 	reqs = list(
-		/obj/item/roguegem/blue = 2,
-		/obj/item/rogueore/gold = 2)
+		/obj/item/roguegem/red = 1,
+		/obj/item/roguegem/yellow = 1)
 	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/alchemy/d2ros
 	name = "transmute diamonds to riddle of steel" /// holy grail requires legendary. (sell price on average is 350. ruby and diamond worth 100 each. you get to legndary you deserve 150-200 profit)
 	result = list(/obj/item/riddleofsteel = 1)
 	reqs = list(
-		/obj/item/roguegem/diamond = 2,
-		/obj/item/rogueore/iron = 1,
+		/obj/item/roguegem/diamond = 1,
+		/obj/item/rogueore/iron = 3, //3 iron and 1 coal, same as the ratio of materials in a greatforge.
 		/obj/item/rogueore/coal = 1)
 	craftdiff = 6
 
 /datum/crafting_recipe/roguetown/alchemy/e2s
-	name = "transmute steel to silver" // This is gonna be ass to make. Have fun. (2 gold ORE, and 4 steel INGOTs, and 2 seffira)
-	result = list(/obj/item/ingot/silver = 1)
+	name = "transmute steel to silver" // Making it is still pretty involved, but at least now you aren't wasting 3 entire ingots of steel plus almost 300 mammon worth of potential profit for a single silver ingot.
+	result = list(/obj/item/ingot/silver = 4)
 	reqs = list(/obj/item/rogueore/gold = 2, /obj/item/ingot/steel = 4, /obj/item/roguegem/violet = 2)
 	craftdiff = 6
 

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -349,7 +349,7 @@
 	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/alchemy/r2dia
-	name = "transmute ruby to iamond"
+	name = "transmute ruby to diamond"
 	result = list(/obj/item/roguegem/diamond = 1)
 	reqs = list(
 		/obj/item/roguegem/red = 1,

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -172,15 +172,15 @@
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/alchemy/antipreg_pot
-	name = "Anti Pregnancy Potion"
+	name = "Sterility Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/antipregnancy)
-	reqs = list(/obj/item/reagent_containers/glass/bottle = 1, /obj/item/ash = 1, /obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 1)
+	reqs = list(/obj/item/reagent_containers/glass/bottle = 1, /obj/item/reagent_containers/powder/crystalglass = 1, /obj/item/clothing/head/peaceflower = 1)
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/alchemy/antipreg_pot_3x
-	name = "3x Anti Pregnancy Potion"
+	name = "3x Sterility Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/antipregnancy,/obj/item/reagent_containers/glass/bottle/rogue/antipregnancy,/obj/item/reagent_containers/glass/bottle/rogue/antipregnancy)
-	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/ash = 2, /obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 2)
+	reqs = list(/obj/item/reagent_containers/glass/bottle = 3, /obj/item/reagent_containers/powder/crystalglass = 2, /obj/item/clothing/head/peaceflower = 2)
 	craftdiff = 1
 
 /// bottle craft

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -388,6 +388,7 @@
 	result = list(
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate)
 	reqs = list(
 		/obj/item/reagent_containers/powder/gemerald = 1,
@@ -397,6 +398,8 @@
 /datum/crafting_recipe/roguetown/alchemy/s2sub
 	name = "Sublimate Sapphire Dust"
 	result = list(
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
@@ -413,6 +416,9 @@
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate)
 	reqs = list(
 		/obj/item/reagent_containers/powder/blortz = 1,
@@ -422,6 +428,9 @@
 /datum/crafting_recipe/roguetown/alchemy/r2sub
 	name = "Sublimate Ruby Dust"
 	result = list(
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
@@ -444,7 +453,11 @@
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
-		/obj/item/reagent_containers/powder/sublimate)
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,)
 	reqs = list(
 		/obj/item/reagent_containers/powder/dorpel = 1,
 		/obj/item/reagent_containers/powder/moondust = 1)
@@ -464,7 +477,19 @@
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
 		/obj/item/reagent_containers/powder/sublimate,
-		/obj/item/reagent_containers/powder/sublimate)
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,
+		/obj/item/reagent_containers/powder/sublimate,)
 	reqs = list(
 		/obj/item/reagent_containers/powder/mfire = 1,
 		/obj/item/reagent_containers/powder/moondust = 1)

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -264,6 +264,12 @@
 	craftdiff = 0
 	subtype_reqs = TRUE
 
+/datum/crafting_recipe/roguetown/alchemy/w2l
+	name = "combine small logs into large log"
+	result = list(/obj/item/grown/log/tree = 1)
+	reqs = list(/obj/item/grown/log/tree/small = 2, /obj/item/natural/fibers)
+	craftdiff = 0
+
 /datum/crafting_recipe/roguetown/alchemy/l2coa
 	name = "transmute log to coal"
 	result = list(/obj/item/rogueore/coal = 4)

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -70,7 +70,7 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/minorhealthpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1,
-		/obj/item/reagent_containers/food/snacks/grown/herbs = 2,
+		/obj/item/reagent_containers/food/snacks/grown/herbs = 1,
 		/obj/item/ash = 1)
 	craftdiff = 0
 

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -11,8 +11,8 @@
 	list_reagents = list(/datum/reagent/medicine/majorhealthpot = 45)
 
 /obj/item/reagent_containers/glass/bottle/rogue/sublimeambrosia
-	list_reagents = list(/datum/reagent/medicine/sublimeambrosia = 5)
-	
+	list_reagents = list(/datum/reagent/medicine/sublimeambrosia = 45)
+
 /obj/item/reagent_containers/glass/bottle/rogue/manapot
 	list_reagents = list(/datum/reagent/medicine/manapot = 45)
 

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -85,12 +85,6 @@
 	M.adjustToxLoss(3, 0)
 	M.blood_volume = min(M.blood_volume+100, BLOOD_VOLUME_MAXIMUM) // Full to bursting.
 
-/datum/chemical_reaction/sublime_ambrosia
-	name = "Sublime Ambrosia"
-	id = /datum/reagent/medicine/sublimeambrosia
-	results = list(/datum/reagent/medicine/sublimeambrosia = 5)
-	required_reagents = list (/datum/reagent/medicine/healthpot = 45, /datum/reagent/medicine/minorhealthpot = 45, /datum/reagent/medicine/majorhealthpot = 45)
-
 /datum/reagent/medicine/sublimeambrosia
 	name = "Sublime Ambrosia"
 	description = "Rapidly regenerates all types of damage, and reverses death."
@@ -112,6 +106,7 @@
 		M.update_damage_overlays()
 	M.adjustBruteLoss(-4.5*REM, 0)
 	M.adjustFireLoss(-4.5*REM, 0)
+	M.adjustToxLoss(-4.5*REM, 0)
 	M.adjustOxyLoss(-9, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -9*REM)
 	M.adjustCloneLoss(-9*REM, 0)
@@ -120,7 +115,7 @@
 
 /datum/reagent/medicine/sublimeambrosia/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(iscarbon(M) && M.stat == DEAD)
-		if(M.mob_biotypes & MOB_UNDEAD)
+		if(M.mob_biotypes & MOB_UNDEAD)//cure rot first
 			return FALSE
 		if(!M.revive(full_heal = FALSE))
 			M.visible_message(span_notice("[M]'s body does not seem to react to the ambrosia..."))

--- a/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -11,7 +11,7 @@
 	name = "3x Paralysis Poison"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,/obj/item/reagent_containers/glass/bottle/rogue/paralysispot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/glass/bottle = 3,
 		/obj/item/reagent_containers/powder/crystalglass = 2,
 		/obj/item/natural/antler = 2)
 	craftdiff = 4
@@ -21,7 +21,6 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/soporpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1,
-		/obj/item/ash = 1,
 		/obj/item/reagent_containers/powder/crystalglass = 1,
 		/obj/item/reagent_containers/food/snacks/grown/carrot = 1 )
 	craftdiff = 4

--- a/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -3,6 +3,7 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/paralysispot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/ash = 1,
 		/obj/item/reagent_containers/powder/crystalglass = 1,
 		/obj/item/natural/antler = 1)
 	craftdiff = 4
@@ -12,6 +13,7 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,/obj/item/reagent_containers/glass/bottle/rogue/paralysispot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/ash = 2,
 		/obj/item/reagent_containers/powder/crystalglass = 2,
 		/obj/item/natural/antler = 2)
 	craftdiff = 4
@@ -21,6 +23,7 @@
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/soporpot)
 	reqs = list(
 		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/ash = 1,
 		/obj/item/reagent_containers/powder/crystalglass = 1,
 		/obj/item/reagent_containers/food/snacks/grown/carrot = 1 )
 	craftdiff = 4

--- a/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/modular_hearthstone/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -1,47 +1,74 @@
 /datum/crafting_recipe/roguetown/alchemy/paralysispot
-	name = "Paralysis Potion"
+	name = "Paralysis Poison"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/paralysispot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 3, 
-		/obj/item/hearthnatural/beespider_fang = 1 )
-	craftdiff = 5
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/crystalglass = 1,
+		/obj/item/natural/antler = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/alchemy/paralysispot3x
+	name = "3x Paralysis Poison"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,/obj/item/reagent_containers/glass/bottle/rogue/paralysispot,/obj/item/reagent_containers/glass/bottle/rogue/paralysispot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/crystalglass = 2,
+		/obj/item/natural/antler = 2)
+	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/alchemy/soporpot
 	name = "Soporific Poison"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/soporpot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/ash = 1, 
-		/obj/item/natural/worms/leech = 1,
-		/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 5 )
-	craftdiff = 2
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/ash = 1,
+		/obj/item/reagent_containers/powder/crystalglass = 1,
+		/obj/item/reagent_containers/food/snacks/grown/carrot = 1 )
+	craftdiff = 4
 
-/datum/crafting_recipe/roguetown/alchemy/soporpotx3
-	name = "Soporific Poison (x3)"
+/datum/crafting_recipe/roguetown/alchemy/soporpot3x
+	name = "3x Soporific Poison"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/soporpot, /obj/item/reagent_containers/glass/bottle/rogue/soporpot, /obj/item/reagent_containers/glass/bottle/rogue/soporpot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 3, 
-		/obj/item/ash = 3, 
-		/obj/item/natural/worms/leech = 3,
-		/obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison = 15 )
-	craftdiff = 2
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/ash = 2,
+		/obj/item/reagent_containers/powder/crystalglass = 2,
+		/obj/item/reagent_containers/food/snacks/grown/carrot = 2 )
+	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/alchemy/fortitudepot
 	name = "Fortitude Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/fortitudepot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 1, 
-		/obj/item/natural/volf_head = 1)
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/natural/hide = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/fortitudepot3x
+	name = "3x Fortitude Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/fortitudepot,/obj/item/reagent_containers/glass/bottle/rogue/fortitudepot,/obj/item/reagent_containers/glass/bottle/rogue/fortitudepot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
+		/obj/item/natural/hide = 2)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/swiftnesspot
 	name = "Swiftness Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/swiftnesspot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 1, 
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/natural/antler = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/swiftnesspot3x
+	name = "3x Swiftness Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/swiftnesspot,/obj/item/reagent_containers/glass/bottle/rogue/swiftnesspot,/obj/item/reagent_containers/glass/bottle/rogue/swiftnesspot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
 		/obj/item/natural/antler = 2)
 	craftdiff = 3
 
@@ -49,28 +76,53 @@
 	name = "Alacrity Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/alacritypot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 1, 
-		/obj/item/organ/eyes = 1)
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/reagent_containers/food/snacks/grown/carrot = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/alacritypot3x
+	name = "3x Alacrity Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/alacritypot,/obj/item/reagent_containers/glass/bottle/rogue/alacritypot,/obj/item/reagent_containers/glass/bottle/rogue/alacritypot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
+		/obj/item/reagent_containers/food/snacks/grown/carrot = 2)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/luckpot
 	name = "Luck Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/luckpot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 2, 
-		/obj/item/rogueore/gold = 1, 
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
 		/obj/item/roguegem/green = 1)
-	craftdiff = 6
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/luckpot3x
+	name = "3x Luck Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/luckpot,/obj/item/reagent_containers/glass/bottle/rogue/luckpot,/obj/item/reagent_containers/glass/bottle/rogue/luckpot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
+		/obj/item/roguegem/green = 2)
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/endurancepot
 	name = "Endurance Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/endurancepot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 1, 
-		/obj/item/reagent_containers/food/snacks/grown/apple = 2, 
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/reagent_containers/food/snacks/rogue/meat = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/endurancepot3x
+	name = "3x Endurance Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/endurancepot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
 		/obj/item/reagent_containers/food/snacks/rogue/meat = 2)
 	craftdiff = 3
 
@@ -78,62 +130,109 @@
 	name = "Ironskin Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/constitutionpot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 2, 
-		/obj/item/rogueore/iron = 3, 
-		/obj/item/natural/stone = 3)
-	craftdiff = 6
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/rogueore/iron = 1)
+	craftdiff = 3
 
-/datum/crafting_recipe/roguetown/alchemy/invispot
-	name = "Invisibility Potion"
-	result = list(/obj/item/reagent_containers/glass/bottle/rogue/invispot)
+/datum/crafting_recipe/roguetown/alchemy/constitutionpot3x
+	name = "3x Ironskin Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/constitutionpot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 3, 
-		/obj/item/reagent_containers/food/snacks/smallrat = 1)
-	craftdiff = 6
-
-/datum/crafting_recipe/roguetown/alchemy/nullmagicpot
-	name = "Null Magic Potion"
-	result = list(/obj/item/reagent_containers/glass/bottle/rogue/nullmagicpot)
-	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 3, 
-		/obj/item/natural/volf_head = 1, 
-		/obj/item/reagent_containers/food/snacks/fat = 2)
-	craftdiff = 6
-
-/datum/crafting_recipe/roguetown/alchemy/trekkersdelight
-	name = "Trekker's Delight"
-	result = list(/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight)
-	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 1, 
-		/obj/item/reagent_containers/powder/salt = 1,
-		/obj/item/natural/dirtclod = 1,
-		/obj/item/soul_fragment/essence = 1,)
-	craftdiff = 2
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
+		/obj/item/rogueore/iron = 2)
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/intellectpot
 	name = "Intellect Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/intellectpot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 1, 
-		/obj/item/natural/bone = 2, 
-		/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed = 2 )
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/intellectpot3x
+	name = "3x Intellect Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/intellectpot,/obj/item/reagent_containers/glass/bottle/rogue/intellectpot,/obj/item/reagent_containers/glass/bottle/rogue/intellectpot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
+		/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 2)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/invispot
+	name = "Invisibility Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/invispot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/crystalglass = 1,
+		/obj/item/reagent_containers/food/snacks/grown/carrot = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/alchemy/invispot3x
+	name = "3x Invisibility Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/invispot,/obj/item/reagent_containers/glass/bottle/rogue/invispot,/obj/item/reagent_containers/glass/bottle/rogue/invispot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/crystalglass = 2,
+		/obj/item/reagent_containers/food/snacks/grown/carrot = 2)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/alchemy/nullmagicpot
+	name = "Null Magic Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/nullmagicpot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/crystalglass = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/alchemy/nullmagicpot3x
+	name = "3x Null Magic Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/nullmagicpot,/obj/item/reagent_containers/glass/bottle/rogue/nullmagicpot,/obj/item/reagent_containers/glass/bottle/rogue/nullmagicpot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/crystalglass = 2,
+		/obj/item/reagent_containers/powder/sublimate = 2)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/alchemy/trekkersdelight
+	name = "Trekker's Delight Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/natural/dirtclod = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/alchemy/trekkersdelight3x
+	name = "3x Trekker's Delight"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight,/obj/item/reagent_containers/glass/bottle/rogue/trekkersdelight)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
+		/obj/item/natural/dirtclod = 2)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/virilitypot
 	name = "Virility Potion"
 	result = list(/obj/item/reagent_containers/glass/bottle/rogue/virilitypot)
 	reqs = list(
-		/obj/item/reagent_containers/glass/bottle = 1, 
-		/obj/item/reagent_containers/powder/sublimate = 1, 
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
 		/obj/item/clothing/head/peaceflower = 1)
-	craftdiff = 2
+	craftdiff = 1
 
-
+/datum/crafting_recipe/roguetown/alchemy/virilitypot3x
+	name = "Virility Potion"
+	result = list(/obj/item/reagent_containers/glass/bottle/rogue/virilitypot)
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/powder/sublimate = 2,
+		/obj/item/clothing/head/peaceflower = 2)
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/alchemy/bloodworms
 	name = "x5 Blood Worms"
@@ -143,3 +242,21 @@
 		/obj/item/reagent_containers/food/snacks/rogue/meat = 1)
 	craftdiff = 1
 
+/datum/crafting_recipe/roguetown/alchemy/bonestack
+	name = "x6 Bones"
+	result = list(/obj/item/natural/bundle/bone/full)//Mostly useful for fertilizer
+	reqs = list(
+		/obj/item/natural/worms/bloodworms = 5,
+		/obj/item/reagent_containers/powder/salt = 1,
+		/obj/item/natural/stone = 1)
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/alchemy/mudcrab
+	name = "Mudcrab"
+	verbage_simple = "transmute"
+	result = list(/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab)
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/fishfresh/crab = 1,
+		/obj/item/reagent_containers/powder/sublimate = 1,
+		/obj/item/natural/dirtclod = 1)
+	craftdiff = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This update alters several recipes, improves the gem progression line, improves the return on investment for silver, and adds triplicate recipes for all of the newer potions added by Hearthstone. Here is an itemized list of all changes made in this PR:

- Changes the parent item of gems from ruby to alchemical glass. Alchemical glass is a mineral with properties that allow it to absorb magic, making it useful for infusions, and can be produced by transmuting a stone with sublimate. When milled, it becomes crystal dust, an ingredient used instead of sublimate when creating certain inverse potions.
- Adds a subtype of the gemstone for ruby, adds a recipe for turquoise to ruby, modifies turquoise to diamond into ruby to diamond and modifies the gem randomization to not give alchemical glass.
- Quartz renamed to Turquoise
- Bogcrab renamed to mudcrab, made a true omnivore, and given a description.
- Ozium recipe now produces a poppy flower, using 1 berry, 1 ash, and 1 dried swampweed.
- Newer moondust recipe now creates Purest Moondust in exchange for 1 moondust, 1 dried westleach, and 5u of berry poison, meaning the original recipe (dry westleach + ash) produces the impure version used for sublimate.
- Added a recipe for Spice, using 1 ash, 1 dry swampleaf, and 5u of berry poison
- All single potion recipes standardized to use only 1 of each ingredient. (plus a bottle)
- All 3x potion recipes standardized to use 2 of each ingredient. (and 3 bottles of course)
- Minor health potion changed to herbs and ash
- Health potion changed to berries and ash
- Major health potion changed to apple, ash, and bone (since it can mend broken bones); Difficulty lowered from 5 to 4
- Sublime Ambrosia recipe changed from a chemical reaction to an alchemical recipe. At Difficulty 5, mix 1 minor health potion, 1 health potion, and 1 major health potion with ash and sublimate to make 1 bottle of Sublime Ambrosia, a powerful restorative that heals damaged organs, rapidly heals all other damage types, and can even resurrect the dead, provided they are cured of rot first.
- 3x variant of Sublime Ambrosia is an outlier. At Difficulty 6, fill 1 of 3 bottles with equal parts minor, major, and standard health potion and mix it with Malum's Fire, obtained by milling a Riddle of Steel. 
- All tiers of gem above toper are achieved by adding 1 toper to that gem. Sublimate value for each gem is double the number of topers used to make it. So basically, each gem tier up increases sublimate value by 2.
- A riddle of steel now costs 1 diamond, 3 iron ore, and 1 coal.
- Malum's Fire, another outlier, is worth a whopping 24 sublimate when mixed with moondust; double the value of the diamond used to make it. Go figure, it's literally the fire of creation.
- Silver recipe gives 4 ingots instead of just 1, recipe is otherwise unchanged.
- Combine fresh swampleaf with a berry to get a poison berry.
- Combine a poison berry with a bundle of herbs to get a non-poisonous berry
- A large log is now worth 4 coal when transmuted (subtype restriction is in place so you can't use small logs to exploit it)
- You can now transmute two small logs with a fiber to get a large log
- You can now transmute a coal back into 4 stones
- Paralysis poison is now made with ash, crystal powder, and an antler; the inverse of Swiftness potion (which swaps out c-dust for sublimate and needs no ash)
- Soporific poison is now made with ash, crystal powder and a carrot; the inverse of Alacrity potion (which is now made with sublimate and a carrot and needs no ash)
- Fortitude potion is now sublimate and hide
- Swiftness potion is now sublimate and antler
- Alacrity potion is now sublimate and carrot
- Luck potion is now sublimate and a gemerald
- Endurance potion is now sublimate and meat
- Ironskin potion is now only sublimate and iron ore
- Intellect potion is now sublimate and dry swampweed
- Invisibility potion is now crystal dust and carrot
- Null Magic potion is now crystal dust and sublimate
- Trekker's Delight potion is now sublimate and dirt clod
- Virility potion is now sublimate and peacebloom (Eora flower basically)
- Sterility potion is now crystal dust and peacebloom
- Peacebloom can be created by transmuting crystal dust, a poppy flower, and a stone knife together.
- Combine 5 bloodworms with 1 pile of salt and 1 stone to get a stack of 6 bones
- Combine a crab (fishable with bloodworms), a clod of dirt, and a pile of sublimate to conjure a living mudcrab, useful for cleaning up discarded food and leaving droppings to mix fertilizer with.
- Apothecary now starts with master alchemy skill, journeyman farming, and expert knife-fighting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most people don't have a reason to play alchemist, and I once tried to go from zero to Riddle one round on Hearthstone. Four hours into that, with four furnaces pumping out coal, and I only made a single diamond. I was less than halfway to the riddle. That's BS. Let's make alchemy fun again.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
