### PR TITLE
Tones down the "Cursed Blood" Perk

### DIFF
--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -431,7 +431,7 @@
 	name = "Cursed Blood (Vampire)"
 	desc = "You are cursed by Levishth, a lone vampire forced to roam the lands and drink blood to survive, albeit 'immortal'. Whether you are Ancient or a new vampire, you are no lord or no spawn and have no reason to antagonize the mortals beyond occasionally finding blood to keep you going. (You area vampire but NOT an ANTAGONIST.)"
 //	desc = "You've existed long before the gods existed, you know the truth and have no reason to worship them. You are faithless. After attaining power, Levishth has cursed your people, bringing bad omens where ever you go. For this reason, the people of Stonehedge have shunned you and discriminated against you, there is no possible way an antediluvian will ever hold a position of power in Stonehedge, let alone be welcomed. Levishth has only shown favor to one antediluvian, rewarding them with the title of Vampire Lord, and gifting them powers far beyond that of a regular nitecreacher. Your pale skin, fangs, and eerie eyes are EASILY identifable features, so it is best to stay covered at all times in public areas."
-	value = 3
+	value = 8
 
 /datum/quirk/vampire/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -449,6 +449,8 @@
 /datum/antagonist/vampirelord/lesser/secret/on_gain()
 	. = ..()
 	owner.current.verbs -= /mob/living/carbon/human/proc/vampire_telepathy
+	REMOVE_TRAIT(owner.current, TRAIT_NOROGSTAM, "[type]")
+	REMOVE_TRAIT(owner.current, TRAIT_NOPAIN, "[type]")
 
 /datum/antagonist/vampirelord/lesser/secret/roundend_report()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adjusts the vampire quirk price from 3 to 8,
Removed the NOSTAM and NOPAIN perks from the vamp trait


## Why It's Good For The Game

To provide some context for this PR, lets discuss what EXACTLY people with this trait got. 

First and most importantly, they got to entirely ignore the stamina system; allowing users to win almost any encounter for the small price of 3 perk points.

Secondly, they had wonderful traits like NOPAIN, making is so that WHEN you got a lucky hit on a vampire, it did functionally nothing without a crit. Not to mention all the more passive benefits like not needing to interact with the mood system, being immune to ambushes, not needing food/water, and on-demand Aheals. 

Removing the NOSTAMINA and NOPAIN perks for vampires takes care of what I and plenty of players consider the most problematic parts of this extremely unbalanced quirk, and increasing the quirk price to 8 seems quite reasonable considering the sheer amount of benefit still provided by it.