### PR TITLE
devotion shit and other shit

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -76,6 +76,7 @@
 #define TRAIT_ABYSSOR_SWIM "Blessing of Tides" //less base fatigue drain when swimming
 #define TRAIT_NORTHMAN "Worshipper of the Norse" //recognized by vikings and allies
 #define TRAIT_FAITHLESS "Ignorant" //being faithless means gods won't really help you, will they
+#define TRAIT_SNEK "Levishth's Resolve" //immune to infections of all types
 
 #define TRAIT_KNEESTINGER_IMMUNITY "Kneestinger Immunity"
 #define TRAIT_BASHDOORS "bashdoors"
@@ -161,6 +162,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_SHOCKIMMUNE = "I am immune to electrical shocks.",
 	TRAIT_NOSLEEP = span_warning("I can't sleep."),
 	TRAIT_ROT_EATER = span_necrosis("I can eat rotten food."),
+	TRAIT_SNEK = span_necrosis("I heal from infections and am immune to them"),
 	TRAIT_ORGAN_EATER = span_bloody("I can eat organs and raw flesh."),
 	TRAIT_KNEESTINGER_IMMUNITY = "I am immune to the shock of kneestingers.",
 	TRAIT_VINE_WALKER = "I can gracefully cross through weepvines.",

--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -6,10 +6,10 @@
 #define CLERIC_T4 4
 
 #define CLERIC_REQ_0 0
-#define CLERIC_REQ_1 100
-#define CLERIC_REQ_2 250
-#define CLERIC_REQ_3 500
-#define CLERIC_REQ_4 750
+#define CLERIC_REQ_1 75
+#define CLERIC_REQ_2 150
+#define CLERIC_REQ_3 350
+#define CLERIC_REQ_4 500
 
 // Cleric Holder Datums
 
@@ -33,7 +33,7 @@
 	/// How much progression is gained per process call
 	var/passive_progression_gain = 0
 	/// How much devotion is gained per prayer cycle
-	var/prayer_effectiveness = 5
+	var/prayer_effectiveness = 8
 	/// Spells we have granted thus far
 	var/list/granted_spells
 

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -8,7 +8,6 @@
 	domain = "Beginnings, Hope, Dawn. Setting the path. Flames, Sunlight, Illumination. (Active Energies)"
 	desc = "Elysius, The Golden Dragon."
 	worshippers = "The Noble Hearted, Zealots, Warriors and Healers."
-	t0 = /obj/effect/proc_holder/spell/invoked/diagnose
 	t1 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue
 	t2 = /obj/effect/proc_holder/spell/invoked/heal
 	t3 = /obj/effect/proc_holder/spell/invoked/revive
@@ -79,7 +78,6 @@
 	desc = "Yamais is the guardian, the crypt-scribe, and the great remembrance. She who watches makes certain each soul reaches its owed afterlife. It is Yamais who remembers peoples actions and worth. Yamais does not take kindly to necromancy which goes against the natural cycle. Though she permits willing undead to return, and has even turned her gaze from liches such as the baelnornes of the elven kingdoms."
 	worshippers = "The Dead, Mourners, Gravekeepers"
 	mob_traits = list(TRAIT_SOUL_EXAMINE)
-	t0 = /obj/effect/proc_holder/spell/invoked/diagnose
 	t1 = /obj/effect/proc_holder/spell/targeted/burialrite
 	t2 = /obj/effect/proc_holder/spell/targeted/churn
 	t3 = /obj/effect/proc_holder/spell/targeted/soulspeak

--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -13,10 +13,15 @@
 	domain = "God of Chaos and Lies; the great manipulator. He who covets power for the sake of power and nothing else."
 	desc = "Discovered long ago, Levisth gives power to the weak who do his bidding,elevating them in time. There are many tales of those who serve the greatsnake, all which eventuate with tales of how it yearns to gain power over all things, jealous of it's 'rivals' the other gods."
 	worshippers = "Power-Hungry, Powerful, Charismatic, Liers."
-	mob_traits = list(TRAIT_WILD_EATER)
+	mob_traits = list(TRAIT_NASTY_EATER, TRAIT_SNEK, TRAIT_ZOMBIE_IMMUNE) //had to add zombie immune so as not to double dip when making the infection immune
+	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen
+	t1 = /obj/effect/proc_holder/spell/invoked/invisibility
+	t2 = /obj/effect/proc_holder/spell/targeted/soulspeak
+	t3 = /obj/effect/proc_holder/spell/invoked/projectile/sickness
+	t4 = /obj/effect/proc_holder/spell/invoked/revive_inhumen
 	confess_lines = list(
-		"Praisseethe Greatssnake!!",
-		"LONG LIVE HISSSS FORME!!",
+		"Praisssse the Greatssssnake!!",
+		"LONG LIVE HISSSS FORM!!",
 		"HISSSSSSS!!!",
 	)
 
@@ -26,6 +31,7 @@
 	desc = "Jayx is known as the Herald of change, often depicted as a two-tailed comet or Phoenix. The Divine Phoenix represents the immortal cycle of growth and advancement, often a god of both magic and art; they are known more than anything as the passage of time itself and bright blue magical fire. (Mana)"
 	worshippers = "Mages, Alchemists, Soul-Searchers, Fateweavers, Supernatural Creatures, Soothsayers."
 	mob_traits = list(TRAIT_ZJUMP)
+	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen
 	confess_lines = list(
 		"THE PHOENIX BURNS BRIGHT AND PURE!",
 		"IN HIS FLAMES I AM REBORN!",
@@ -38,6 +44,7 @@
 	desc = "Man turned God, the 'Giver' 'The Thief' stole fire from 'Elysius' and gave it to primitive Mortal Kin huddled in darkness and demands the riches flame creates in sacrifice."
 	worshippers = "Free-Men, Outlaws and Frontiersmen"
 	mob_traits = list(TRAIT_COMMIE, TRAIT_ZJUMP)
+	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen
 	t1 = /obj/effect/proc_holder/spell/invoked/Joy_takes_flight
 	t2 = /obj/effect/proc_holder/spell/invoked/Laughing_god
 	t3 = /obj/effect/proc_holder/spell/invoked/Smokebomb
@@ -53,6 +60,7 @@
     desc = "The Sacrifice wishes to take from you, and for you to give it willingly. You will never get it back if you go too far. But you will always have the sacrifice."
     worshippers = "Nihilists, Gamblers, Warlocks, and Villains."
     mob_traits = list(TRAIT_CRACKHEAD)
+    t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen
     confess_lines = list(
         "I do not yearn for anything!!",
         "I CANNOT LOSE WHAT I COULD NEVER HOPE TO HOLD!",

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -281,8 +281,7 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	examine_text = span_notice("They appear not entirely whole, as if some part of them was left behind.")
 	effectedstats = list("strength" = -2, "perception" = -2, "intelligence" = -2, "constitution" = -2, "endurance" = -2, "speed" = -2)
-	duration = 30 MINUTES
-	var/extralives = 1
+	duration = 10 MINUTES
 
 /// SURRENDERING DEBUFFS
 

--- a/code/datums/wounds/the_only_cure.dm
+++ b/code/datums/wounds/the_only_cure.dm
@@ -15,6 +15,10 @@
 	var/werewolf_infection_timer
 
 /datum/wound/proc/zombie_infect_attempt()
+	var/mob/living/carbon/M = owner
+	if(HAS_TRAIT(M, TRAIT_SNEK))
+		M.apply_status_effect(/datum/status_effect/buff/healing)
+		return FALSE
 	if(QDELETED(src) || QDELETED(owner) || QDELETED(bodypart_owner))
 		return
 	if(zombie_infection_timer || werewolf_infection_timer || !ishuman(owner) || !prob(zombie_infection_probability))
@@ -51,6 +55,10 @@
 	return TRUE
 
 /datum/wound/proc/werewolf_infect_attempt()
+	var/mob/living/carbon/M = owner
+	if(HAS_TRAIT(M, TRAIT_SNEK))
+		M.apply_status_effect(/datum/status_effect/buff/healing)
+		return FALSE
 	if(QDELETED(src) || QDELETED(owner) || QDELETED(bodypart_owner))
 		return FALSE
 	if(zombie_infection_timer || werewolf_infection_timer || !ishuman(owner) || !prob(werewolf_infection_probability))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -17,6 +17,8 @@
 	switch(H.patron?.type)
 		if(/datum/patron/divine/astrata)
 			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+		if(/datum/patron/inhumen/zizo)
+			neck = /obj/item/clothing/neck/roguetown/psicross/skull
 		if(/datum/patron/divine/noc)
 			neck = /obj/item/clothing/neck/roguetown/psicross/noc
 		if(/datum/patron/divine/dendor)
@@ -50,12 +52,11 @@
 			H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank_up_to(/datum/skill/magic/holy, 4, TRUE)
 			H.change_stat("intelligence", 2)
-			H.change_stat("perception", 1) // More intelligence and no speed penalty for Life Clerics.
+			H.change_stat("speed", 1) // More intelligence and no speed penalty for Life Clerics.
 			H.change_stat("strength", 1)
 			H.change_stat("constitution", 2)
 			H.change_stat("endurance", 2)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
-			H.mind.AddSpell(new	/obj/effect/proc_holder/spell/invoked/lesser_heal)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/guidance5e)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 		if("War Cleric")
@@ -82,7 +83,6 @@
 			H.change_stat("speed", -1)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
-			H.mind.AddSpell(new	/obj/effect/proc_holder/spell/invoked/lesser_heal)
 			H.mind.AddSpell(new	/obj/effect/proc_holder/spell/targeted/churn)
 		if("Nature Cleric")
 			H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -16,6 +16,8 @@
 /datum/outfit/job/roguetown/adventurer/paladin/pre_equip(mob/living/carbon/human/H)
 	..()
 	switch(H.patron.name)
+		if("Zizo")
+			neck = /obj/item/clothing/neck/roguetown/psicross/skull
 		if("Astrata")
 			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
 		if("Dendor")

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -97,6 +97,7 @@
 		H.change_stat("constitution", 2)
 		H.change_stat("endurance", 3)
 		H.change_stat("speed", -1)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 		H.cmode_music = 'sound/music/combat_clergy.ogg'
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -278,6 +278,11 @@
 
 /datum/reagent/infection/on_mob_life(mob/living/carbon/M)
 	var/heat = (BODYTEMP_AUTORECOVERY_MINIMUM + clamp(volume, 3, 15)) * fever_multiplier
+	if(HAS_TRAIT(M, TRAIT_SNEK))
+		M.apply_status_effect(/datum/status_effect/buff/healing)
+		if(holder.has_reagent(/datum/reagent/infection))
+			holder.remove_reagent(/datum/reagent/infection, 9999)
+			return
 	M.adjustToxLoss(damage_tick, 0)
 	if (lethal_fever)
 		M.adjust_bodytemperature(heat, 0)
@@ -295,6 +300,24 @@
 	damage_tick = 0.1
 	lethal_fever = FALSE
 
+/datum/reagent/infection/minor/on_mob_life(mob/living/carbon/M)
+	var/heat = (BODYTEMP_AUTORECOVERY_MINIMUM + clamp(volume, 3, 15)) * fever_multiplier
+	if(HAS_TRAIT(M, TRAIT_SNEK))
+		M.apply_status_effect(/datum/status_effect/buff/healing)
+		if(holder.has_reagent(/datum/reagent/infection/minor))
+			holder.remove_reagent(/datum/reagent/infection/minor, 9999)
+			return
+	M.adjustToxLoss(damage_tick, 0)
+	if (lethal_fever)
+		M.adjust_bodytemperature(heat, 0)
+		if (prob(5))
+			to_chat(M, span_warning("A wicked heat settles within me... I feel ill. Very ill."))
+	else
+		M.adjust_bodytemperature(heat, 0, BODYTEMP_HEAT_DAMAGE_LIMIT - 1)
+		if (prob(5))
+			to_chat(M, span_warning("I feel a horrible chill despite the sweat rolling from my brow..."))
+	return ..()
+
 /datum/reagent/infection/major
 	name = "excess melancholic humour"
 	description = "Kingsfield's Bane. Excess melancholic has killed thousands, and even Pestra's greatest struggle against its insidious advance."
@@ -303,6 +326,11 @@
 	fever_multiplier = 3
 
 /datum/reagent/infection/major/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_SNEK))
+		M.apply_status_effect(/datum/status_effect/buff/healing)
+		if(holder.has_reagent(/datum/reagent/infection/major))
+			holder.remove_reagent(/datum/reagent/infection/major, 9999)
+			return
 	if (M.badluck(1))
 		M.reagents.add_reagent(src, rand(1,3))
 		to_chat(M, span_small("I feel even worse..."))
@@ -360,7 +388,7 @@
 /datum/reagent/medicine/purify/on_mob_life(mob/living/carbon/human/M)
 	M.adjustFireLoss(0.5*REM, 0)
 	M.heal_wounds(3)
-	
+	M.reagents.remove_reagent(/datum/reagent/infection, 9999)
 	// Iterate through all body parts
 	for (var/obj/item/bodypart/B in M.bodyparts)
 		// Iterate through wounds on each body part

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -66,26 +66,10 @@
 	if(isliving(targets[1]))
 		testing("revived1")
 		var/mob/living/target = targets[1]
-		if(HAS_TRAIT(target, TRAIT_FAITHLESS))
-			to_chat(user, span_warning("Elysius light has no effect! He denies aiding a non-believer!"))
-			return FALSE
 		if(target == user)
 			return FALSE
 		if(target.stat < DEAD)
 			to_chat(user, span_warning("Nothing happens."))
-			return FALSE
-
-		var/datum/status_effect/debuff/death_weaken/rip = target.has_status_effect(/datum/status_effect/debuff/death_weaken)
-		if(rip)
-			if(!rip.extralives)
-				rip.examine_text = span_danger("Their body looks entirely devoid of a soul.")
-				to_chat(user, span_warning("Nothing happens."))
-				return FALSE
-			target.visible_message(span_danger("[target]'s soul is violently ripped from Necra's gentle embrace!"), span_userdanger("I am roughly pulled out of Necra's dark embrace, but a piece of me will stay with her forevermore!"))
-			rip.extralives--
-
-		if(HAS_TRAIT(target, TRAIT_NECRA_CURSE))
-			to_chat(user, span_warning("Necra's grasp prevents revival."))
 			return FALSE
 		if(GLOB.tod == "night")
 			to_chat(user, span_warning("Let there be light."))

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -19,9 +19,6 @@
 	. = ..()
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
-		if(HAS_TRAIT(target, TRAIT_FAITHLESS)) //being faithless means god doesnt really want to help you now, does it
-			to_chat(user, span_warning("My prayers reach deaf ears - the Gods refuse to aid a non-believer!"))
-			return FALSE
 		if(user.patron?.undead_hater && (target.mob_biotypes & MOB_UNDEAD)) //positive energy harms the undead
 			target.visible_message(span_danger("[target] is burned by holy light!"), span_userdanger("I'm burned by holy light!"))
 			target.adjustFireLoss(10)
@@ -113,37 +110,6 @@
 				if (HAS_TRAIT(user, TRAIT_PACIFISM))
 					conditional_buff = TRUE
 					situational_bonus += 1.5
-			if(/datum/patron/inhumen/zizo)
-				target.visible_message(span_info("shadow-like interwoven snakes lunge and dispere into [target]!"), span_notice("The shadows leave a chill, blood in my mouth -- yet I feel healed."))
-				// set up a ritual pile of bones (or just cast near a stack of bones whatever) around us for massive bonuses, cap at 50 for 75 healing total (wowie)
-				situational_bonus = 0
-				for (var/obj/item/stack/sheet/bone/O in oview(5, user))
-					situational_bonus += (O.amount * 0.5)
-				if (situational_bonus > 0)
-					conditional_buff = TRUE
-					situational_bonus = min(situational_bonus, 5)
-			if(/datum/patron/inhumen/graggar)
-				target.visible_message(span_info("Blue Phoenix-Fires Envelop [target]!"), span_notice("The life around me pales as manna and the phoenix roar fills me. I am restored!"))
-				// if you've got lingering toxin damage, you get healed more, but your bonus healing doesn't affect toxin
-				var/toxloss = target.getToxLoss()
-				if (toxloss >= 10)
-					conditional_buff = TRUE
-					situational_bonus = 2.5
-					target.adjustToxLoss(situational_bonus) // remember we do a global toxloss adjust down below so this is okay
-			if(/datum/patron/inhumen/matthios)
-				target.visible_message(span_info("Shadows unfurl outward and across [target] as their form is restored!"), span_notice("I'm bathed in a... strange holy light?"))
-				// COMRADES! WE MUST BAND TOGETHER!
-				if (HAS_TRAIT(target, TRAIT_COMMIE))
-					conditional_buff = TRUE
-					situational_bonus = 2.5
-			if(/datum/patron/inhumen/baotha)
-				target.visible_message(span_info("A wreath of... strange light passes over [target]?"), span_notice("Something feels taken.. but the pain subsides. I am whole again."))
-				// i wanted to do something with pain here but it doesn't seem like pain is actually parameterized anywhere so... better necra it is - if they're below 50% health, they get 25 extra healing
-				if (iscarbon(target))
-					var/mob/living/carbon/C = target
-					if (C.health <= (C.maxHealth * 0.5))
-						conditional_buff = TRUE
-						situational_bonus = 2.5
 			if(/datum/patron/godless)
 				target.visible_message(span_info("Raw energy in white and dark interwoven hews flow toward [target]."), span_notice("My wounds close without cause."))
 			else
@@ -189,9 +155,6 @@
 	. = ..()
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
-		if(HAS_TRAIT(target, TRAIT_FAITHLESS)) //being faithless means god doesnt really want to help you now, does it
-			to_chat(user, span_warning("My prayers reach deaf ears - the Gods refuse to aid a non-believer!"))
-			return FALSE
 		if(user.patron?.undead_hater && (target.mob_biotypes & MOB_UNDEAD)) //positive energy harms the undead
 			target.visible_message(span_danger("[target] is burned by holy light!"), span_userdanger("I'm burned by holy light!"))
 			target.adjustFireLoss(25)

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -118,9 +118,6 @@
 	. = ..()
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/human_target = targets[1]
-		if(HAS_TRAIT(human_target, TRAIT_FAITHLESS)) //go find a surgeon, non-believer
-			to_chat(user, span_warning("Hermeir turns their faith from this one; they did not have any faith, or worse..."))
-			return FALSE
 		for(var/obj/item/bodypart/limb as anything in get_limbs(human_target, user))
 			if(human_target.get_bodypart(limb.body_zone) || !limb.attach_limb(human_target))
 				continue
@@ -164,9 +161,6 @@
 	if(isliving(targets[1]))
 		testing("curerot1")
 		var/mob/living/target = targets[1]
-		if(HAS_TRAIT(target, TRAIT_FAITHLESS))
-			to_chat(user, span_warning("Pestra's grace has no effect, they do not wish to aid a non-believer..."))
-			return FALSE
 		if(target == user)
 			return FALSE
 		var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)

--- a/code/modules/spells/roguetown/acolyte/zizo.dm
+++ b/code/modules/spells/roguetown/acolyte/zizo.dm
@@ -1,0 +1,136 @@
+/obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen
+	name = "Heal"
+	overlay_state = "lesserheal"
+	releasedrain = 30
+	chargedrain = 0
+	chargetime = 0
+	range = 4
+	warnie = "sydwarning"
+	movement_interrupt = FALSE
+	sound = 'sound/magic/heal.ogg'
+	invocation_type = "none"
+	associated_skill = /datum/skill/magic/holy
+	antimagic_allowed = TRUE
+	charge_max = 10 SECONDS
+	miracle = TRUE
+	devotion_cost = 10
+
+/obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen/cast(list/targets, mob/living/user)
+	. = ..()
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		var/conditional_buff = FALSE
+		var/situational_bonus = 1
+		switch(user.patron.type)
+			if(/datum/patron/inhumen/zizo)
+				target.visible_message(span_info("shadow-like interwoven snakes lunge and dispere into [target]!"), span_notice("The shadows leave a chill, blood in my mouth -- yet I feel healed."))
+				// set up a ritual pile of bones (or just cast near a stack of bones whatever) around us for massive bonuses, cap at 50 for 75 healing total (wowie)
+				situational_bonus = 0
+				for (var/obj/item/stack/sheet/bone/O in oview(5, user))
+					situational_bonus += (O.amount * 0.5)
+				if (situational_bonus > 0)
+					conditional_buff = TRUE
+					situational_bonus = min(situational_bonus, 5)
+			if(/datum/patron/inhumen/graggar)
+				target.visible_message(span_info("Blue Phoenix-Fires Envelop [target]!"), span_notice("The life around me pales as manna and the phoenix roar fills me. I am restored!"))
+				// if you've got lingering toxin damage, you get healed more, but your bonus healing doesn't affect toxin
+				var/toxloss = target.getToxLoss()
+				if (toxloss >= 10)
+					conditional_buff = TRUE
+					situational_bonus = 2.5
+					target.adjustToxLoss(situational_bonus) // remember we do a global toxloss adjust down below so this is okay
+			if(/datum/patron/inhumen/matthios)
+				target.visible_message(span_info("Shadows unfurl outward and across [target] as their form is restored!"), span_notice("I'm bathed in a... strange holy light?"))
+				// COMRADES! WE MUST BAND TOGETHER!
+				if (HAS_TRAIT(target, TRAIT_COMMIE))
+					conditional_buff = TRUE
+					situational_bonus = 2.5
+			if(/datum/patron/inhumen/baotha)
+				target.visible_message(span_info("A wreath of... strange light passes over [target]?"), span_notice("Something feels taken.. but the pain subsides. I am whole again."))
+				// i wanted to do something with pain here but it doesn't seem like pain is actually parameterized anywhere so... better necra it is - if they're below 50% health, they get 25 extra healing
+				if (iscarbon(target))
+					var/mob/living/carbon/C = target
+					if (C.health <= (C.maxHealth * 0.5))
+						conditional_buff = TRUE
+						situational_bonus = 2.5
+			if(/datum/patron/godless)
+				target.visible_message(span_info("Raw energy in white and dark interwoven hews flow toward [target]."), span_notice("My wounds close without cause."))
+			else
+				target.visible_message(span_info("A choral sound comes from above and [target] is healed!"), span_notice("I am bathed in healing choral hymns!"))
+		var/healing = 2.5
+		if (conditional_buff)
+			to_chat(user, "Channeling my patron's power is easier in these conditions!")
+			healing += situational_bonus
+
+		if(iscarbon(target))
+			var/mob/living/carbon/C = target
+			var/datum/status_effect/buff/healing/heal_effect = C.apply_status_effect(/datum/status_effect/buff/healing)
+			heal_effect.healing_on_tick = healing
+		else
+			target.adjustBruteLoss(-healing*10)
+			target.adjustFireLoss(-healing*10)
+		return TRUE
+	return FALSE
+
+/obj/effect/proc_holder/spell/invoked/revive_inhumen
+	name = "Ressurection"
+	overlay_state = "revive"
+	releasedrain = 90
+	chargedrain = 0
+	chargetime = 30
+	range = 1
+	warnie = "sydwarning"
+	no_early_release = TRUE
+	movement_interrupt = TRUE
+	chargedloop = /datum/looping_sound/invokeholy
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	sound = 'sound/magic/revive.ogg'
+	associated_skill = /datum/skill/magic/holy
+	antimagic_allowed = TRUE
+	charge_max = 2 MINUTES
+	miracle = TRUE
+	devotion_cost = 100
+	var/revive_pq = PQ_GAIN_REVIVE
+
+/obj/effect/proc_holder/spell/invoked/revive_inhumen/cast(list/targets, mob/living/user)
+	. = ..()
+	if(isliving(targets[1]))
+		testing("revived1")
+		var/mob/living/target = targets[1]
+		if(target == user)
+			return FALSE
+		if(target.stat < DEAD)
+			to_chat(user, span_warning("Nothing happens."))
+			return FALSE
+		target.adjustOxyLoss(-target.getOxyLoss())
+		if(!target.revive(full_heal = FALSE))
+			to_chat(user, span_warning("Nothing happens."))
+			return FALSE
+		testing("revived2")
+		var/mob/living/carbon/spirit/underworld_spirit = target.get_spirit()
+		if(underworld_spirit)
+			var/mob/dead/observer/ghost = underworld_spirit.ghostize()
+			qdel(underworld_spirit)
+			ghost.mind.transfer_to(target, TRUE)
+		target.grab_ghost(force = TRUE)
+		target.remove_client_colour(/datum/client_colour/monochrome)
+		target.emote("breathgasp")
+		target.Jitter(100)
+		if(isseelie(target))
+			var/mob/living/carbon/human/fairy_target = target
+			fairy_target.set_heartattack(FALSE)
+			var/obj/item/organ/wings/Wing = fairy_target.getorganslot(ORGAN_SLOT_WINGS)
+			if(Wing == null)
+				var/wing_type = fairy_target.dna.species.organs[ORGAN_SLOT_WINGS]
+				var/obj/item/organ/wings/seelie/new_wings = new wing_type()
+				new_wings.Insert(fairy_target)
+		target.update_body()
+		target.visible_message(span_notice("[target] is revived by a gloaming hollow light!"), span_green("I awake from the realm before death, cut short of slipping entirely.."))
+		if(target.mind)
+			if(revive_pq && !HAS_TRAIT(target, TRAIT_IWASREVIVED) && user?.ckey)
+				adjust_playerquality(revive_pq, user.ckey)
+				ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
+			target.mind.remove_antag_datum(/datum/antagonist/zombie)
+		return TRUE
+	return FALSE
+

--- a/code/modules/spells/roguetown/warlock.dm
+++ b/code/modules/spells/roguetown/warlock.dm
@@ -27,11 +27,6 @@
 	. = ..()
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
-		if(!ignore_faithless)
-			if(!HAS_TRAIT(target, TRAIT_FAITHLESS)) //how do you like it?
-				to_chat(user, span_warning("The [patronname] refuses to aid a believer in the divine or inhumen - They should ask their own |GOD| for help."))
-				return FALSE
-
 		target.visible_message(span_info("[target] "+othernotification), span_notice(targetnotification))
 		if(iscarbon(target))
 			var/mob/living/carbon/C = target

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3465,6 +3465,7 @@
 #include "code\modules\spells\roguetown\acolyte\noc.dm"
 #include "code\modules\spells\roguetown\acolyte\pestra.dm"
 #include "code\modules\spells\roguetown\acolyte\xylix.dm"
+#include "code\modules\spells\roguetown\acolyte\zizo.dm"
 #include "code\modules\spells\roguetown\spells5e\cantrips5e.dm"
 #include "code\modules\spells\roguetown\spells5e\spellscrolls.dm"
 #include "code\modules\spells\spell_types\aimed.dm"


### PR DESCRIPTION
* added zizo snake god spells for clerics and paladins
* added zizo trait to ignore and get a 10 second heal from infections
* said spells are revival and heal spell that wont harm undead.
* devotion break points lowered to all other codebase standard
* prayer generation increased default across board
* removed revival limiter (no one was reviving people anyway...)
* removed faithless cannot be healed or revived restrictions
* adjusted PURITY chem to also remove mundane infections. prior it was jsut for werewolf and zombie (if caught before transform/death)