### PR TITLE
Makes Warlocks Magical

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -18,6 +18,7 @@
 	H.adjust_blindness(-3)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e)
+		H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn) // base arcane skill means all warlocks get 2 points to spend
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 1, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, pick(0,1), TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 2, TRUE)
@@ -155,6 +156,8 @@
 	H.change_stat("perception", 2)
 	H.change_stat("constitution", 1)
 
+	H.mind.adjust_spellpoints(3) // general arcane power, less total gain than other trees, 5 points total (it's hard to give "celestial" a real spell theme)
+
 	givehealing(H, patronchoice, TRUE)
 
 	H.visible_message(span_info("I made a deal with a celestial being from the heavens."))
@@ -190,6 +193,10 @@
 	H.change_stat("constitution", 2)
 	H.change_stat("endurance", 1)
 	H.change_stat("speed", -1)
+
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/acidsplash5e)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/frostbite5e) // "water" and ice magic, less arcane power because armor and dodge training
+
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_WATERBREATHING, TRAIT_GENERIC)
@@ -199,8 +206,8 @@
 /datum/outfit/job/roguetown/adventurer/warlock/proc/fiendpatron(mob/living/carbon/human/H, patronchoice) //hellish fiend
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
-		
+	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
+	
 	head = /obj/item/clothing/head/roguetown/roguehood/red
 	mask = /obj/item/clothing/mask/rogue/facemask/gold
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
@@ -216,6 +223,7 @@
 	H.change_stat("perception", 2)
 	H.change_stat("constitution", 1)
 
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fireball) // fireball is a very strong spell, fiendkiss makes it even stronger
 	ADD_TRAIT(H, TRAIT_NOFIRE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_FIENDKISS, TRAIT_GENERIC)
 
@@ -241,6 +249,10 @@
 	H.change_stat("endurance", 1) // 
 	H.change_stat("speed", 2)
 	H.change_stat("fortune", 2)
+
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/haste)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/push_spell) // going with wind theme, speed and airblast, possibly eventual picker for "which type of genie did you make a deal with"
+
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 
 	H.visible_message(span_info("I made a deal with a djinn from a magic lamptern."))
@@ -267,8 +279,7 @@
 	H.change_stat("perception", 2)
 	H.change_stat("constitution", 1)
 
-	H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)
-	H.mind.adjust_spellpoints(4)
+	H.mind.adjust_spellpoints(4) // 8 total spell points after arcane adjust; forbidden eldritch knowledge to build your own spellbook, but you get nothing else
 
 	H.visible_message(span_info("Most minds would fracture having spoken to the creecher I made a deal with..."))
 
@@ -308,6 +319,8 @@
 	H.change_stat("endurance", 1)
 	H.change_stat("speed", -1)
 
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/greenflameblade5e) // put that new weapon to work! martial focus means less magic
+	
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
@@ -351,13 +364,15 @@
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 3)
 
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/cloakofflies)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/infestation5e)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/chilltouch5e) // decay-themed magic and a skeletal hand to attack people with
+
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 
 	H.visible_message(span_info("I made a deal with a horror from the grave."))
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/cloakofflies)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/infestation5e)
 
 ///////////////////////////////
 //	Faithless Healing


### PR DESCRIPTION
## About The Pull Request

**Adds magic tab to all warlocks,** with a base 2 spell points given by the class's base Arcane skill.

Archfae patron is unchanged, but the base arcane skill gain from it gives warlocks 4 total spell points.

Celestial patron gives 3 additional spellpoints for a total of 5, because "space" isn't a workable spell theme, so "cosmic knowledge". General utility at player discretion.

Abyssal patron gives acid splash and frostbite, themed around water. Less power because armor + dodge + good spellcasting would be too much at once.

Fiend gives fireball. Also lowered its arcane skillgain by one, so 3 total spell points, because fireball is already a lot of power.

Genie gives haste and repulse, themed around wind. Flammen wanted a picker here for D&D genie types, but a fire or water genie would just overlap with Fiend and Abyssal anyway. Maybe for a second pass.

Old One gets nothing new, because it's already magical. 8 total spell points with complete freedom to pick is a fairly high budget already, hard to justify buffing it further.

Hexblade gets green flame blade. Same reasoning as Abyssal. Side note, Hexblade really should give +2 in general weapon skill for 4 total in the selected weapon type, but that's technically out of scope for this PR.

Undead gets chilling touch, partly because it already had a decent power level and doesn't need a lot more, and partly to avoid bloating the spell list to silly levels.

Also, Pact of Power will give +1 skill point, because it raises arcane skill.

## Why It's Good For The Game

The fantasy of a D&D warlock is that of a magician who struck a deal with an otherworldly being, while most warlocks on this server don't have anything in the way of magic other than Eldritch Blast. The _meme_ portrayal is a guy who only spams Eldritch Blast, sure, but anyone seriously into D&D knows there's a lot more magic to the class than that. This change should live up to what most people expect in a "warlock".

The class is also generally pretty weak at the moment. Most patrons leave you as a random schmuck with no combat skills, few utility skills, no real magic to think of, and a pact that is a nice bonus feature but not a good class core. And occasionally gets you mugged for your fancy amulet. Currently the Old One patron makes you slightly weaker than most mage subclasses in exchange for the added power of a pact (either a fun gimmick or something more seriously helpful), which is a reasonable tradeoff, and this is what the rest of the patrons were balanced around in this PR. I'm not entirely sure this is enough of a buff, honestly, but I don't want to overdo this and see Warlock-tide.