### PR TITLE
Warlock Martial Skills

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -112,6 +112,7 @@
 			H.set_blindness(0)
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/archfeypatron(mob/living/carbon/human/H, patronchoice)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
@@ -139,9 +140,10 @@
 	H.visible_message(span_info("I made a deal with an archseelie from the wild."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/celestialpatron(mob/living/carbon/human/H, patronchoice)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
@@ -163,6 +165,7 @@
 	H.visible_message(span_info("I made a deal with a celestial being from the heavens."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/fathomlesspatron(mob/living/carbon/human/H, patronchoice) // a watery creature
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
@@ -204,6 +207,7 @@
 	H.visible_message(span_info("I made a deal with a fathomless creecher of the sea."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/fiendpatron(mob/living/carbon/human/H, patronchoice) //hellish fiend
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
@@ -233,12 +237,13 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE) 
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 2, TRUE)
 
 	head = /obj/item/clothing/head/roguetown/roguehood/shalal
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 	gloves = /obj/item/clothing/gloves/roguetown/angle
-	beltr = /obj/item/wisp_lantern
+	beltl = /obj/item/wisp_lantern
+	beltr = /obj/item/rogueweapon/sword/sabre
 	belt = /obj/item/storage/belt/rogue/leather/shalal
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
@@ -258,6 +263,7 @@
 	H.visible_message(span_info("I made a deal with a djinn from a magic lamptern."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/goopatron(mob/living/carbon/human/H, patronchoice)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
@@ -284,10 +290,12 @@
 	H.visible_message(span_info("Most minds would fracture having spoken to the creecher I made a deal with..."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/hexbladepatron(mob/living/carbon/human/H, patronchoice)
-	H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 1, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 1, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 1, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 1, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 1, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 1, TRUE)
 
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	gloves = /obj/item/clothing/gloves/roguetown/leather
@@ -319,7 +327,8 @@
 	H.change_stat("endurance", 1)
 	H.change_stat("speed", -1)
 
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/greenflameblade5e) // put that new weapon to work! martial focus means less magic
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/greenflameblade5e) 
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending5e) // put that new weapon to work! martial focus means less magic
 	
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
@@ -327,6 +336,8 @@
 	H.visible_message(span_info("I made a deal with a sentient weapon."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/undeadpatron(mob/living/carbon/human/H, patronchoice)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, rand(1,3), TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, rand(1,3), TRUE)
@@ -499,34 +510,34 @@
 	switch(item_pick)
 		if(1)
 			item_type = /obj/item/rogueweapon/sword
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		if(2)
 			item_type = /obj/item/rogueweapon/greatsword
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		if(3)
 			item_type = /obj/item/rogueweapon/spear
-			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		if(4)
 			item_type = /obj/item/rogueweapon/halberd
-			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		if(5)
 			item_type = /obj/item/rogueweapon/stoneaxe
-			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 		if(6)
 			item_type = /obj/item/rogueweapon/stoneaxe/battle
-			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 		if(7)
 			item_type = /obj/item/rogueweapon/mace/steel
-			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 		if(8)
 			item_type = /obj/item/rogueweapon/huntingknife/idagger/steel
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		if(9)
 			item_type = /obj/item/rogueweapon/flail
-			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 		if(10)
 			item_type = /obj/item/rogueweapon/whip
-			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 		
 	var/obj/item/item
 	item = new item_type


### PR DESCRIPTION
## About The Pull Request

Gives all warlocks 2 skill in their main weapon, depending on patron. I even remembered to make this "up_to" so people can't abuse quirks to get Master skill rank.
Gives Celestial patron warlocks chainmail, replacing halfplate armor they aren't trained to use.
Gives Genie patron warlocks a saber (standard one-handed version, not Shalal), because despite having sword skill even before this PR they didn't actually have a sword.
Gives Hexblade patron warlocks Mending, because only getting green-flame blade sucks and it also makes thematic sense for them to be able to maintain their expensive armor.
Makes Pact of Strength give 3 skill in the selected weapon instead of 2, both buffing Hexblade to Expert skill and ensuring for other Patrons that the magic weapon you made a soul pact to get is better than whatever you happened to spawn with. This will rarely result in a non-Hexblade Pact of Strength warlock hitting the jackpot and having Master skill, but it's either that or making the weapon assignment adjust skills "up_to", which would make Hexblade no better at its chosen weapon than any other patron, and that would be either too much on other warlocks or not enough on Hexblade.

## Why It's Good For The Game

Baseline weapon competence is something given to basically every adventurer class; even the mage subclasses at least get 2 knife skill. Some of the patron choices are clearly meant to be melee-focused but don't have the skills to accomplish anything in melee. Apprentice skill level puts them on par with Life Clerics; still bad, but definitely knows how to swing their weapon properly. This mostly just saves time swinging at the sentient dummies.
Pact of Strength should automatically make warlocks fairly good at using whatever weapon they get. Journeyman is as high as you can reasonably train; they still need to rely on your magic and patron blessings in a fight against a professional.
Hexblade warlocks should basically be able to hold their own in a melee fight, with light magic use tipping the scales, because melee is the entire point of Hexblade and they don't get much else to lean on. Kinda like an arcane version of the Paladin class. Expert skill is the minimum to reliably do that at the current level of skill inflation, which, again, matches Paladins.