### PR TITLE
Fixes Spelldancer magic menu

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/bladesinger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/bladesinger.dm
@@ -54,3 +54,4 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/boomingblade5e)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/greenflameblade5e)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish)
+	H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Spelldancers weren't given access to the magic menu to spend their skill points. This fixes that

## Why It's Good For The Game
Bugs bad

