### PR TITLE
Uncommon Patron Trait Changes

### DIFF
--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -30,7 +30,7 @@
 	domain = "God of Twilight and Change. Magic. Transformation. Dusk/Dawn. Crisis/Resolution."
 	desc = "Jayx is known as the Herald of change, often depicted as a two-tailed comet or Phoenix. The Divine Phoenix represents the immortal cycle of growth and advancement, often a god of both magic and art; they are known more than anything as the passage of time itself and bright blue magical fire. (Mana)"
 	worshippers = "Mages, Alchemists, Soul-Searchers, Fateweavers, Supernatural Creatures, Soothsayers."
-	mob_traits = list(TRAIT_ZJUMP)
+	mob_traits = list(TRAIT_ANTISCRYING)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen
 	confess_lines = list(
 		"THE PHOENIX BURNS BRIGHT AND PURE!",
@@ -43,7 +43,7 @@
 	domain = "Thievery. Cunning. "
 	desc = "Man turned God, the 'Giver' 'The Thief' stole fire from 'Elysius' and gave it to primitive Mortal Kin huddled in darkness and demands the riches flame creates in sacrifice."
 	worshippers = "Free-Men, Outlaws and Frontiersmen"
-	mob_traits = list(TRAIT_COMMIE, TRAIT_ZJUMP)
+	mob_traits = list(TRAIT_COMMIE, TRAIT_GOODRUNNER)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal_inhumen
 	t1 = /obj/effect/proc_holder/spell/invoked/Joy_takes_flight
 	t2 = /obj/effect/proc_holder/spell/invoked/Laughing_god


### PR DESCRIPTION
## About The Pull Request

Replaces Jayx's jump trait with anti-scrying.
Replaces the Thief's jump trait with good runner.

## Why It's Good For The Game

Being able to jump ten feet in the air because you worship a certain god is dumb. Did not fit Jayx thematically whatsoever, while anti-scrying makes some sense for a magic god. Good runner makes sense for a god of thieves without giving any special capabilities.