### PR TITLE
Makes Warlock pact-weapon functionality more obvious. Also adds every potential initial weapon.

### DIFF
--- a/code/datums/components/pact_weapon.dm
+++ b/code/datums/components/pact_weapon.dm
@@ -5,7 +5,7 @@
 	var/weapons = list(
 		/obj/item/rogueweapon/huntingknife/cleaver, /obj/item/rogueweapon/huntingknife/idagger/steel, //daggers
 		/obj/item/rogueweapon/sword/rapier, /obj/item/rogueweapon/sword/long, /obj/item/rogueweapon/greatsword, //swords
-		/obj/item/rogueweapon/mace, //blunt
+		/obj/item/rogueweapon/mace/steel, /obj/item/rogueweapon/mace/goden/steel //blunt
 		/obj/item/rogueweapon/stoneaxe/woodcut/steel, /obj/item/rogueweapon/stoneaxe/battle, //axes
 		/obj/item/rogueweapon/whip, /obj/item/rogueweapon/flail, //flails
 		/obj/item/rogueweapon/spear, /obj/item/rogueweapon/halberd, /obj/item/rogueweapon/sickle/scythe //polearms
@@ -19,7 +19,7 @@
 		weapon_owner = L
 		weapon = parent
 		weapon.name += " of the [patronchoice]"
-		weapon.desc += " It is enchanted to use arcane skill rather than it's regular skill"
+		weapon.desc += " It is enchanted to use arcane skill rather than its regular skill. Right click with an empty hand to change this weapon's form."
 		weapon.force *= 1.2
 		weapon.max_blade_int *= 1.2
 		weapon.max_integrity *= 1.2


### PR DESCRIPTION
## About The Pull Request

- Changes the Warlock pact weapon description to actually tell you that you can change its shape. Previously this was secret information only known to people who have scrutinized the codebase.
- Also adds steel mace and steel grand mace to transformation options.

## Why It's Good For The Game

- Why is this information not available anywhere?
- Steel mace and grand mace are potential initial forms, but if you change off them, you can't get them back.