### PR TITLE
Wearing gloves will no longer make you immune to electrical magic

### DIFF
--- a/code/modules/clothing/rogueclothes/gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves.dm
@@ -8,6 +8,7 @@
 	bloody_icon_state = "bloodyhands"
 	sleevetype = "shirt"
 	max_heat_protection_temperature = 361
+	siemens_coefficient = 1
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/gloves/roguetown/carapace


### PR DESCRIPTION
## About The Pull Request

Raises default siemens coefficient of all obtainable gloves to 1, instead of inherited 0.5 from normal SS13 code. This should make electrical magic work properly - tested in-game with var editing.

## Why It's Good For The Game

Electrical spells call electrocute code with the minimal possible electrical power of 1, to cause the minimum possible effect. Electrical code multiplies base electrical power by siemens of gloves, and if the product is under 1, the actual shock effect doesn't fire. All Roguetown gloves currently have default siemens of 0.5, inherited from default SS13 gloves. So fingerless leather gloves make you immune to lightning bolts. I don't think I need to explain the issue with this.
I'm not sure how someone didn't notice this earlier.