### PR TITLE
Warlock pact weapons should start fully-repaired now. Also adds a few weapons.

### DIFF
--- a/code/datums/components/pact_weapon.dm
+++ b/code/datums/components/pact_weapon.dm
@@ -7,8 +7,8 @@
 		/obj/item/rogueweapon/sword/rapier, /obj/item/rogueweapon/sword/long, /obj/item/rogueweapon/greatsword, //swords
 		/obj/item/rogueweapon/mace/steel, /obj/item/rogueweapon/mace/goden/steel, //blunt
 		/obj/item/rogueweapon/stoneaxe/woodcut/steel, /obj/item/rogueweapon/stoneaxe/battle, //axes
-		/obj/item/rogueweapon/whip, /obj/item/rogueweapon/flail, //flails
-		/obj/item/rogueweapon/spear, /obj/item/rogueweapon/halberd, /obj/item/rogueweapon/sickle/scythe //polearms
+		/obj/item/rogueweapon/whip, /obj/item/rogueweapon/flail/sflail, /obj/item/rogueweapon/flail/peasantwarflail, //flails
+		/obj/item/rogueweapon/spear, /obj/item/rogueweapon/halberd, /obj/item/rogueweapon/eaglebeak, /obj/item/rogueweapon/sickle/scythe //polearms
 		)
 
 /datum/component/pact_weapon/Initialize(mob/living/L, pc)
@@ -22,7 +22,9 @@
 		weapon.desc += " It is enchanted to use arcane skill rather than its regular skill. Right click with an empty hand to change this weapon's form."
 		weapon.force *= 1.2
 		weapon.max_blade_int *= 1.2
+		weapon.blade_int = weapon.max_blade_int
 		weapon.max_integrity *= 1.2
+		weapon.obj_integrity = weapon.max_integrity
 		weapon.minstr = 1
 		weapon.associated_skill = /datum/skill/magic/arcane
 		//var/mutable_appearance/magic_overlay = mutable_appearance('icons/effects/effects.dmi', "electricity")


### PR DESCRIPTION
## About The Pull Request

- Enchantment currently increases max integrity; now the current integrity is increased to the new maximum.
- Added peasant war flail and eagle beak to the weapon swap list.
- Pact flail is now made out of steel.

## Why It's Good For The Game

- Bugfix.
- Some variant of every other normally-craftable weapon is already available. I don't think these two are uniquely strong compared to the steel mace, greatsword, or whip. And as I see it more blunt weapons generally means less deaths which means more RP. Hopefully.
- Every pact weapon option except the flail is currently the steel equivalent, this is evening it out.

I genuinely think this should be the last thing I feel the need to do for the warlock class. That said I'll probably remember something else 5 hours from now.