### PR TITLE
Maybe we warlocked too hard...

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -118,7 +118,7 @@
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 
 	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/mage
@@ -162,7 +162,7 @@
 	H.change_stat("perception", 2)
 	H.change_stat("constitution", 1)
 
-	H.mind.adjust_spellpoints(3) // general arcane power, less total gain than other trees, 5 points total (it's hard to give "celestial" a real spell theme)
+	H.mind.adjust_spellpoints(2) // general arcane power, less total gain than other trees, 4 points total (it's hard to give "celestial" a real spell theme)
 
 	givehealing(H, patronchoice, TRUE)
 
@@ -271,7 +271,7 @@
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 
 	head = /obj/item/clothing/head/roguetown/roguehood/mage
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
@@ -290,7 +290,7 @@
 	H.change_stat("perception", 2)
 	H.change_stat("constitution", 1)
 
-	H.mind.adjust_spellpoints(4) // 8 total spell points after arcane adjust; forbidden eldritch knowledge to build your own spellbook, but you get nothing else
+	H.mind.adjust_spellpoints(3) // 6 total spell points after arcane adjust; forbidden eldritch knowledge to build your own spellbook, but you get nothing else
 
 	H.visible_message(span_info("Most minds would fracture having spoken to the creecher I made a deal with..."))
 
@@ -301,7 +301,7 @@
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 1, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 1, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE) // patron weapon scales off of arcane for some reason so hexblade needs this for expert weapon skill
+	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE) // patron weapon scales off of arcane for some reason
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
 
 	shoes = /obj/item/clothing/shoes/roguetown/boots
@@ -512,40 +512,29 @@
 ///////////////////////////////
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/giveweapon(mob/living/carbon/human/H, patronchoice)
-	H.mind.adjust_skillrank_up_to(/datum/skill/magic/arcane, 3, TRUE) // guaranteed journeyman-equivalent "weapon" skill for patrons who wouldn't otherwise give it, because magic weapons use magic skill instead of martial
 	var/item_pick = pick(1,2,3,4,5,6,7,8,9,10)
 	var/item_type
 	switch(item_pick)
 		if(1)
 			item_type = /obj/item/rogueweapon/sword
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 		if(2)
 			item_type = /obj/item/rogueweapon/greatsword
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 		if(3)
 			item_type = /obj/item/rogueweapon/spear
-			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 		if(4)
 			item_type = /obj/item/rogueweapon/halberd
-			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 		if(5)
 			item_type = /obj/item/rogueweapon/stoneaxe/battle
-			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 		if(6)
 			item_type = /obj/item/rogueweapon/mace/goden/steel
-			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 		if(7)
 			item_type = /obj/item/rogueweapon/mace/steel
-			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 		if(8)
 			item_type = /obj/item/rogueweapon/huntingknife/idagger/steel
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		if(9)
 			item_type = /obj/item/rogueweapon/flail
-			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 		if(10)
 			item_type = /obj/item/rogueweapon/whip
-			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 
 	var/obj/item/item
 	item = new item_type


### PR DESCRIPTION
## About The Pull Request

- No warlock patron gives more than 3 total arcane skill. Either you get 1 point if you got 1 or 2, or you don't gain any if you already didn't. This lowers the spell point budget by 1 for many patrons.
- Celestial and Old One both lose an inherent spellpoint, considering they seem to be the most used patrons. 4 and 6 are still decent amounts for "arcane cleric" and "caster", and that's before pacts.
- Pact of Strength no longer innately gives journeyman arcane. You can still get journeyman arcane very easily by smacking sentient dummies, but this forces a little brainpower usage instead of instant frag capability.
- Nukes the pointless melee skill gain from patron weapon assignment because the weapon uses arcane skill. Why was this ever here.

## Why It's Good For The Game

Warlock *is* kind of stupid now. Vide wants it reeled back, and despite me being the one to buff it I do too. Ironically the biggest hit here is to old one patron who I didn't touch. Players looking at this class more when the other patrons were made worth a damn, I assume. Also - I might give Celestial an actual spell list centered around utility instead of the bonus spellpoints, so it's harder to frag with them, but I'm too tired for creativity right now.

Actual explanation: Warlock is a generalist class, but should not *excel* at both magic and melee at the same time. Pact of Strength is the main cause of this. And in turn the reason Pact of Strength was an issue was the caster-focused patrons essentially getting expert weapons skill roundstart, on top of spell points. Hexblade could even get *master* weapons. In hindsight this was very stupid. To an extent Pact of Strength was always an issue, it was just attached to a class with basically no other redeeming qualities - if you took it you'd be a fairly spindly guy with expert weapon skill, the ability to throw 20-damage orbs, and nothing else. Not to mention - Swordsmaster quirk paved over all martial skill balance, so none of this stuff really mattered until like two days ago thanks to 15 speed master-skill rapiers being everywhere.

Now Pact of Strength gives you a cool omni-weapon, but you only get sentient-dummy tier weapon skill at most, and you might even need to actually train for that. Much more in line with other pacts giving you a cool artifact moreso than a major power gain; any specific form is now just worse than a flawless or legendary smithed weapon, even to the Warlock, because you can train either to the same skill level. The benefit is versatility (and being able to carry a polearm in your boot).

Remaining potential issue is Hexblade itself, where going all-in with Pact of Power gives you expert "weapons" skill, but you still just outright have bad stats compared to, like, Paladins, and you basically gave up your pact for that (Empowered Blast itself isn't that good). No heavy armor training either, etc. If it's still a problem I'll make Pact of Power give a spellpoint instead of skillgain. Also, in general - Arcane being grindable past Journeyman to a degree normal martial skills aren't, but there are other ways to tune that. Like secretly making pact weapons scale off of reading instead. I *will* resort to this if people grinding magic mid-round just to frag becomes a serious issue.

On a side note: I really need to nerf Lightning Lure harder. It's *the* main thing that makes martial spellcasters so stupid.