### PR TITLE
Lightning Lure cooldown nerf

### DIFF
--- a/code/modules/spells/roguetown/spells5e/cantrips5e.dm
+++ b/code/modules/spells/roguetown/spells5e/cantrips5e.dm
@@ -1135,7 +1135,7 @@
 	overlay_state = "null"
 	releasedrain = 50
 	chargetime = 1
-	charge_max = 5 SECONDS
+	charge_max = 12 SECONDS
 	range = 3
 	warnie = "spellwarning"
 	movement_interrupt = FALSE


### PR DESCRIPTION
## About The Pull Request

Lightning lure cooldown from 5 to 12 seconds.

## Why It's Good For The Game

Strongest spell of any type in the game by far, including most role-exclusive spells, only really rivaled by stuff like Greater Fireball. And I guess *Resurrection*, but that's a given. If you ask a fragger which spell they want out of every spell in the game, this is the first pick after adminbus-exclusive stuff. Auto-targeting lightning bolt but it has 1/4th the cooldown. You can borderline permastun with just Lightning Lure. Awful. One stun should already win you a fight.

It's still cheaper, significantly faster cooldown, and aims for you, the only downside is having to stay in range. I heard one dev or another suggest it'd be fun if the range was inverted - so if someone runs away, they get stunned, but if they keep fighting you, it fizzles. If Lure is an issue still I'll consider that solution.