### PR TITLE
Fortify now called "Rejuvenate", heals some damage on a body part

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -132,7 +132,7 @@
 
 // Miracle
 /obj/effect/proc_holder/spell/invoked/heal
-	name = "Fortify"
+	name = "Rejuvenate"
 	overlay_state = "astrata"
 	releasedrain = 30
 	chargedrain = 0
@@ -172,9 +172,18 @@
 		if(iscarbon(target))
 			var/mob/living/carbon/C = target
 			C.apply_status_effect(/datum/status_effect/buff/fortify)
+			var/obj/item/bodypart/affecting = C.get_bodypart(check_zone(user.zone_selected))
+			if(affecting)
+				if(affecting.heal_damage(30, 30))
+					C.update_damage_overlays()
+				if(affecting.heal_wounds(30))
+					C.update_damage_overlays()
 		else
 			target.adjustBruteLoss(-50)
 			target.adjustFireLoss(-50)
+		target.adjustToxLoss(-30)
+		target.adjustOxyLoss(-30)
+		target.blood_volume += BLOOD_VOLUME_SURVIVE
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

With the power of stolen code from Warlock's healing spell, Fortify now actually does something worth a damn on its own. Still applies buff, heals a base 30 of all damage types to targeted body part (45 after the status buff), restores a good amount of blood.

## Why It's Good For The Game

Player feedback is that holy healing feels pretty lackluster at the moment. This is partly to allow for doctors to actually do things, but the base heal spell is underwhelming even from that perspective (and has to be, it's tier 0) and I rarely see people even use Fortify. Holy healing - especially by clerics from a healing-focused domain - should be robust enough to stabilize people so they can get to a doctor, even if it's impractical to treat *everything* with it. It should be more than just be a way to round someone up from slightly wounded. That said, I'm not buffing base heal for the moment, just this advanced version.

For deeper context this is just restoring classic Blackstone miracle's healing, when you factor in the status effect. You can see the remnants of Blackstone's heal in the simplemob healing - 50 of each type. With this change, 45 of each type with the status effect taken into account.