### PR TITLE
A little more magic for Warlock, and buffs to underused pacts

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -18,7 +18,8 @@
 	H.adjust_blindness(-3)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e)
-		H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn) // base arcane skill means all warlocks get 2 points to spend
+		H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)
+		H.mind.adjust_spellpoints(1) // all warlocks get at least 3 points to spend
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 1, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 2, TRUE)
@@ -91,19 +92,22 @@
 			H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/eldritchblast5e/empowered)
 			H.change_stat("intelligence", 1)
-			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
+			H.mind.adjust_spellpoints(1)
 		if("love") //ring of soulbinding
 			H.put_in_hands(givering(H))
 			ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
+			H.change_stat("endurance", 1)
 			H.set_blindness(0)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/eoracurse)
 		if("health") //make healthier
 			givehealing(H, patronchoice)
+			H.change_stat("constitution", 1)
 			H.set_blindness(0)
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		if("wealth") //Pact of the Talisman
 			ADD_TRAIT(H, TRAIT_SEEPRICES, type)
+			H.mind.adjust_skillrank_up_to(/datum/skill/misc/alchemy, 3, TRUE)
 			H.put_in_hands(giveamulet(patronchoice), FALSE)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 			H.set_blindness(0)
@@ -112,6 +116,7 @@
 			H.set_blindness(0)
 		if("revenge") //give curse
 			givecurse(H, patronchoice)
+			H.change_stat("speed", 1)
 			H.set_blindness(0)
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/archfeypatron(mob/living/carbon/human/H, patronchoice)
@@ -512,6 +517,7 @@
 ///////////////////////////////
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/giveweapon(mob/living/carbon/human/H, patronchoice)
+	H.mind.adjust_skillrank_up_to(/datum/skill/magic/arcane, 3, TRUE)
 	var/item_pick = pick(1,2,3,4,5,6,7,8,9,10)
 	var/item_type
 	switch(item_pick)


### PR DESCRIPTION
## About The Pull Request

- All warlocks now get +1 spell point over previous.
- Power now gives a spell point, instead of leveling arcane. This means no Warlock subclass can achieve Expert arcane skill with a pact weapon. At least, not without grinding in-round.
- Love now gives +1 Endurance.
- Health now gives +1 Constitution.
- Wealth now sets alchemy to 3.
- Revenge now gives +1 Speed.
- Strength now sets arcane to 3 automatically again.

## Why It's Good For The Game

Spell budget on warlocks is very low. Compare Mage Elementalist subclass who gets 6 spell points and 6 more in preset spells, and almost directly better stats than Warlocks, to Old One getting 6 spell points and 1 preset point in Eldritch Blast. Warlocks get pacts to compensate, but going all-in on Pact of Power leaves an Old One warlock with 7 points and empowered blast, which isn't buyable normally but, realistically, it's worth 2 points. This means the most magic-specced Warlock has vastly less overall magic than Elementalist and gets absolutely nothing to compensate for it.
After this change Old One will get 8+2 with Pact of Power, The extra point makes them noticeably more versatile than Elementalist but with a bit less raw power. Old One who takes another pact will end up with 7+1 spell points - still a versatile but overall weak caster in exchange for whatever boon they were given.
Patrons like Abyssal and Undead have a comically low budget of *2* points. If they take a pact like Wealth or Revenge they're just totally cooked; very little magic, very few skills. An extra point will give them a chance to do much of anything without *needing* to rely on pacts like Power and Strength.
This still generally matches the D&D design of Warlocks getting less overall spell slots in exchange for their class features, but ensures all Warlocks can actually pick up a couple cantrips of choice instead of potentially just one spell.

IMO any caster with Expert "weapons" skill is a little too much. Bard Arcanist will be the only one left after this change, if they specialize fully into weapons skill with their College, but Bard is much more martial-focused in general, even in the hybrid roles, while Warlock is ultimately magical at heart. The extra spell point should partly make up for it.

Stat buffs to Love, Health, and Revenge both fit with the lore of those choices - staying power in bed, general health, chasing someone down - and ensure every Warlock ends up with 6 total attribute points, or more if they take the items that buff attributes at the expense of a "real" power. These were generally under-picked anyway.

Wealth pact buff is thematically appropriate, iron to gold and all. Alchemy is also the actual best way to make money, fortune stat be damned, so the "wealth" obsessed warlock ought to know how.

Strength pact change is tedium reduction. Warlocks ought to have reached the limit of mundane training on their special magic pact weapon.