### PR TITLE
Combat music for adventuring clergy and wizards

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -7,6 +7,7 @@
 	vampcompat = FALSE
 	outfit = /datum/outfit/job/roguetown/adventurer/cleric
 	category_tags = list(CTAG_ADVENTURER)
+	cmode_music = 'sound/music/combat_clergy.ogg'
 
 /datum/outfit/job/roguetown/adventurer/cleric
 	allowed_patrons = ALL_CLERIC_PATRONS

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -9,6 +9,7 @@
 	traits_applied = list(TRAIT_HEAVYARMOR)
 	category_tags = list(CTAG_ADVENTURER)
 	maximum_possible_slots = 5		//Supposed to be a rare role, thus why it's in donator category. It's a Templar-equal role.
+	cmode_music = 'sound/music/combat_clergy.ogg'
 
 /datum/outfit/job/roguetown/adventurer/paladin
 	allowed_patrons = ALL_CLERIC_PATRONS

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -6,6 +6,7 @@
 	allowed_races = RACES_ALL_KINDSPLUS
 	outfit = /datum/outfit/job/roguetown/adventurer/mage
 	category_tags = list(CTAG_ADVENTURER)
+	cmode_music = 'sound/music/combat_bandit_mage.ogg'
 
 
 /datum/outfit/job/roguetown/adventurer/mage/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/sorceress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/sorceress.dm
@@ -6,6 +6,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/sorceress
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 	category_tags = list(CTAG_DISABLED)
+	cmode_music = 'sound/music/combat_bandit_mage.ogg'
 
 /datum/outfit/job/roguetown/adventurer/sorceress
 	allowed_patrons = list(/datum/patron/divine/noc)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -8,6 +8,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/warlock
 	//traits_applied = list(TRAIT_DODGEEXPERT)
 	category_tags = list(CTAG_ADVENTURER)
+	cmode_music = 'sound/music/combat_bandit_mage.ogg'
 
 /datum/outfit/job/roguetown/adventurer/warlock
 

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -6,7 +6,6 @@
 	faction = "Station"
 	total_positions = 10
 	spawn_positions = 10
-	cmode_music = 'sound/music/combat_bandit_mage.ogg'
 
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_sexes = list(MALE, FEMALE)
@@ -20,6 +19,8 @@
 	give_bank_account = 2500
 	min_pq = 8
 	max_pq = null
+
+	cmode_music = 'sound/music/combat_bandit_mage.ogg'
 
 /datum/outfit/job/roguetown/magician
 

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -6,6 +6,7 @@
 	faction = "Station"
 	total_positions = 10
 	spawn_positions = 10
+	cmode_music = 'sound/music/combat_bandit_mage.ogg'
 
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_sexes = list(MALE, FEMALE)


### PR DESCRIPTION
## About The Pull Request

Current clergy combat track is applied to holy adventurers - Cleric, Paladin.
Current bandit mage track is applied to most magicians - Mage, Sorceress, Warlock, Magician.

## Why It's Good For The Game

Clergy track makes sense on any "holy" role, and Cleric+Paladin easily get played more than every town church role combined.
Bandit mage track is basically just sitting in the code unused because of the current state of bandits. Name is technically a mismatch now, but it's not the only case of that.
Also having more bangers instead of the very plain default combat music is generally an improvement.

No fancy music for Mage Apprentice because you should be running from the fights, not getting into them.