### PR TITLE
Warlock pact weapon no-embed and stat changes

### DIFF
--- a/code/datums/components/pact_weapon.dm
+++ b/code/datums/components/pact_weapon.dm
@@ -21,11 +21,16 @@
 		weapon.name += " of the [patronchoice]"
 		weapon.desc += " It is enchanted to use arcane skill rather than its regular skill. Right click with an empty hand to change this weapon's form."
 		weapon.force *= 1.2
+		weapon.throwforce *= 1.2
+		weapon.block_chance *= 1.2
+		weapon.armor_penetration *= 1.2
+		weapon.wdefense *= 1.2
 		weapon.max_blade_int *= 1.2
 		weapon.blade_int = weapon.max_blade_int
 		weapon.max_integrity *= 1.2
 		weapon.obj_integrity = weapon.max_integrity
 		weapon.minstr = 1
+		ADD_TRAIT(weapon, TRAIT_NOEMBED, TRAIT_GENERIC)
 		weapon.associated_skill = /datum/skill/magic/arcane
 		//var/mutable_appearance/magic_overlay = mutable_appearance('icons/effects/effects.dmi', "electricity")
 		//item.add_overlay(magic_overlay)


### PR DESCRIPTION
## About The Pull Request

- Gives Warlock pact weapon auxiliary stats equal to Flawless modifiers. It already gets Flawless-tier damage bonus.
- Gives Warlock pact weapon no-embed.

## Why It's Good For The Game

- Pact weapon is entirely statistically outclassed by flawless weapons, and the lack of auxiliary stats makes it very close to even fine weapons, which can be made essentially at round-start by the blacksmith. Legendary (which isn't actually that hard to speedrun) is still significantly better, rewarding in-round effort and all.
- Getting disarmed of your unique weapon is fine, skill issue and all, but not losing it forever because mobs are janky and behave unpredictably when dying or getting butchered. Getting stuck in a guy mid-fight who then runs off is a bit of a middle ground, but still unfun for something irreplaceable.

Requested by some Discordians. No-embed's a good idea because the raw frustration of that is fairly high (embeds are kind of a shit mechanic in general that encourage using already-strong blunt weapons and daggers instead of cooler, weaker swords and axes, but this is an overarching design argument to have on Discord, not in PR descriptions). Stat buffs are maybe more questionable but unique magic weapon being outdone within 5 minutes of blacksmith grinding is kind of sad, especially with half the server population starting with blacksmithing gear thanks to Master Craftsman.
Now, does Warlock *need* this? Well... see my other PR which will be going up shortly. If the class, or at least this pact, is going to be a hybrid of melee and casting they might need the help. (Not the same PR as this, because maintaining scope is good and it's a change that needs to happen regardless of buffing Warlock equipment.)