### PR TITLE
Lightning magic cooldown increase

### DIFF
--- a/code/modules/spells/roguetown/spells5e/cantrips5e.dm
+++ b/code/modules/spells/roguetown/spells5e/cantrips5e.dm
@@ -1135,7 +1135,7 @@
 	overlay_state = "null"
 	releasedrain = 50
 	chargetime = 1
-	charge_max = 12 SECONDS
+	charge_max = 20 SECONDS
 	range = 3
 	warnie = "spellwarning"
 	movement_interrupt = FALSE

--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -10,7 +10,7 @@
 	releasedrain = 30
 	chargedrain = 1
 	chargetime = 15
-	charge_max = 20 SECONDS
+	charge_max = 30 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE


### PR DESCRIPTION
## About The Pull Request

Lightning bolt cooldown 20 -> 30 seconds.
Lightning lure cooldown 12 -> 20 seconds.

## Why It's Good For The Game

Spell that instantly wins a fight for you (you can strip helmets before the stun wears off, and then the guy's still on the ground for a bit as you stab at their uncovered face, it's very stupid) should be very punishing to miss. Increasing cooldowns by 50% for both of them seems fair. I was tempted to outright double the cooldowns, but that would make them very weak outside of 1v1s and group fights should be a thing on this server.
If we're going to have semi-martial classes with access to magic these spells need fixing. Bladedancer, Spellblade mages, Warlocks, even the bard and rogue subclasses, being capable of pulling out an instant win stun bolt while also potentially being able to win a fight the normal way is never going to feel great for anyone other than the person playing as one. This is a patch-job fix and probably needs to be replaced by something deeper in the future. Replacing the shock with immobilized status would be good for someone who wants to go deeper into this. A change like that should revert this cooldown nerf.