### PR TITLE
Elder shrooms will properly produce healing powder when milled

### DIFF
--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -125,7 +125,6 @@
 	can_distill = TRUE
 	mill_result = /obj/item/reagent_containers/powder/heal
 	distill_reagent = /datum/reagent/medicine/shroomt
-	mill_result = /obj/item/reagent_containers/powder/flour // mushroom flour. it exists. and its gross.
 
 /obj/item/reagent_containers/food/snacks/grown/apple/On_Consume(mob/living/eater)
 	..()


### PR DESCRIPTION
## About The Pull Request

Removed a line overwriting the mill result of mushrooms to flour.

## Why It's Good For The Game

More herbal remedies! Or shroom-al remedies in this case. Millstones are harder to come by than barrels so you get something a bit better than just tea. Also makes much more sense than getting flour from _mushrooms_.
Vide added the healing powder result a few weeks ago, but it's been broken since then because flour came second and immediately overwrote it.