### PR TITLE
Sweet music eases the pain

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -310,6 +310,17 @@
 	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -healing_on_tick)
 	owner.adjustCloneLoss(-healing_on_tick, 0)
 
+/atom/movable/screen/alert/status_effect/buff/healing/musicalhealing
+	name = "Musical Regeneration"
+	desc = "Sweet music eases the pain, if only a little..."
+	icon_state = "buff"
+
+/datum/status_effect/buff/healing/musicalhealing
+	id = "musicalhealing"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/healing/musicalhealing
+	duration = 30 SECONDS
+	healing_on_tick = 0.01
+
 /atom/movable/screen/alert/status_effect/buff/fortify
 	name = "Fortifying Miracle"
 	desc = "Divine intervention bolsters me and aids my recovery."

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -45,6 +45,7 @@
 
 /obj/item/rogue/instrument/attack_self(mob/living/user)
 	var/stressevent = /datum/stressevent/music
+	var/healthbonus = 0.01
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 	if(.)
@@ -59,16 +60,22 @@
 			switch(user.mind.get_skill_level(/datum/skill/misc/music))
 				if(1)
 					stressevent = /datum/stressevent/music
+					healthbonus = 0.01
 				if(2)
 					stressevent = /datum/stressevent/music/two
+					healthbonus = 0.05
 				if(3)
 					stressevent = /datum/stressevent/music/three
+					healthbonus = 0.1
 				if(4)
 					stressevent = /datum/stressevent/music/four
+					healthbonus = 0.25
 				if(5)
 					stressevent = /datum/stressevent/music/five
+					healthbonus = 0.5
 				if(6)
 					stressevent = /datum/stressevent/music/six
+					healthbonus = 1
 			START_PROCESSING(SSobj, src)
 
 		if(playing)
@@ -90,6 +97,8 @@
 			soundloop.start()
 		for(var/mob/living/carbon/human/L in viewers(7))
 			L.add_stress(stressevent)
+			var/datum/status_effect/buff/healing/musicalhealing/heal_effect = L.apply_status_effect(/datum/status_effect/buff/healing/musicalhealing)
+			heal_effect.healing_on_tick = healthbonus
 	else
 		playing = FALSE
 		soundloop.stop()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -30,8 +30,8 @@
 			H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 3, TRUE)
 			H.mind.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 2, TRUE)
 			H.mind.adjust_skillrank_up_to(/datum/skill/misc/stealing, 2, TRUE)
-			H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, pick(0,1), TRUE)
-			H.mind.adjust_skillrank_up_to(/datum/skill/misc/music, pick(4,5), TRUE)
+			H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 1, TRUE)
+			H.mind.adjust_skillrank_up_to(/datum/skill/misc/music, 5, TRUE)
 			head = /obj/item/clothing/head/roguetown/bardhat
 			shoes = /obj/item/clothing/shoes/roguetown/boots
 			pants = /obj/item/clothing/under/roguetown/tights/random
@@ -65,7 +65,7 @@
 			H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3 , TRUE)
 			H.mind.adjust_skillrank_up_to(/datum/skill/craft/masonry, 3, TRUE)
 			H.mind.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 3, TRUE)
-			H.mind.adjust_skillrank_up_to(/datum/skill/misc/music, rand(3,5), TRUE)
+			H.mind.adjust_skillrank_up_to(/datum/skill/misc/music, 4, TRUE)
 			head = /obj/item/clothing/head/roguetown/bardhat
 			shoes = /obj/item/clothing/shoes/roguetown/boots
 			pants = /obj/item/clothing/under/roguetown/tights/random
@@ -95,8 +95,8 @@
 			H.mind.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 2, TRUE)
 			H.mind.adjust_skillrank_up_to(/datum/skill/misc/stealing, 1, TRUE)
 			H.mind.adjust_skillrank_up_to(/datum/skill/magic/arcane, 2, TRUE)
-			H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, pick(0,1), TRUE)
-			H.mind.adjust_skillrank_up_to(/datum/skill/misc/music, pick(4,5), TRUE)
+			H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 1, TRUE)
+			H.mind.adjust_skillrank_up_to(/datum/skill/misc/music, 5, TRUE)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/spitfire)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)


### PR DESCRIPTION
## About The Pull Request

Instruments now apply a light healing buff for 30 seconds when applying their stress reduction. Per tick: 1 for legendary, 0.5 for master, 0.25 for expert, 0.1 for journeyman, 0.05 for apprentice, and 0.01 for novice. As a reminder, universal holy "heal" spell is 3 per tick.
Removes RNG from Bard music (and medicine) skills. 4 for Skald, 5 for the others.

I've tested this locally and it seems to work perfectly. The actual buff application is a little jank, needing to restart the instrument to re-apply and persisting if you stop playing while it's still active, but both of these issues apply to the stress buff.

## Why It's Good For The Game

Bards famously buff party members with music, and only slightly less famously heal party members whenever the Cleric's calling out sick. Fulfilling the fantasies of classes defined in D&D and all that.

Balance-wise, it's a fun extra feature to a class chronically outclassed in most respects by Rogue, and still can't heal fast enough to properly replace a Cleric or surgeon (_maybe_ at Legendary, but you need to give up your bardic college for that and I think we should celebrate anyone willing to pick anything other than the "more weapon skill please" option). Total healing of a Legendary bard on listeners will be identical to that of a Cleric with no ritual bonus, but taking three times as long. Masters are half that, Experts are half that again, and anything lower is more for flavor than practical healing. If this seems like a bit much keep in mind that Paladins in plate armor with high weapons training can heal at the _same_ rate as Clerics.

Now that music skill actually does something meaningful, having it be RNG is kind of bad. Skald gets one point less from it being more of a martial fighter and crafting generalist than the other two, probably why it had a lower random range originally. Medicine skill also set to guaranteed 1 entirely because skill RNG is a scourge and I will eliminate it every time I make a PR for a class.

Currently this PR only has any meaningful effect for Bards and Minstrels (towner role, so basically irrelevant); nobody else has enough music skill to do anything impactful and there's no way to gain music skill. The dummy reading trick doesn't work with instruments.