### PR TITLE
Spawner adjustments

### DIFF
--- a/code/game/objects/structures/roguetown/mobspawner.dm
+++ b/code/game/objects/structures/roguetown/mobspawner.dm
@@ -32,7 +32,7 @@ var/global/max_total_spawned_mobs = 30 // New global variable for the total limi
 
 	proc/spawn_and_continue()
 		if (total_spawned_mobs < max_total_spawned_mobs)
-			spawn_random_mobs(3) // Attempt to spawn 3 mobs each time
+			spawn_random_mobs(2) // Attempt to spawn 2 mobs each time
 		start_spawning()
 
 	proc/spawn_random_mobs(var/num_to_spawn)
@@ -55,7 +55,7 @@ var/global/max_total_spawned_mobs = 30 // New global variable for the total limi
 
 	proc/get_random_valid_turf()
 		var/list/valid_turfs = list()
-		for (var/turf/T in range(3, src))
+		for (var/turf/T in range(4, src))
 			if (is_valid_spawn_turf(T))
 				valid_turfs += T
 		if (valid_turfs.len == 0)
@@ -70,7 +70,7 @@ var/global/max_total_spawned_mobs = 30 // New global variable for the total limi
 		for (var/L in adventurer_landmarks)
 			if (get_dist(T, L) < 10)
 				return FALSE
-		if (players_nearby(T, 5))
+		if (players_nearby(T, 10))
 			return FALSE
 		return TRUE
 

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -207,7 +207,7 @@
 	name = ""
 	desc = ""
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF 
-	spawn_time = 3000
+	spawn_time = 3600
 	max_mobs = 1
 	mob_types = list(
 	/mob/living/simple_animal/hostile/rogue/gravelord = 1)
@@ -316,7 +316,7 @@
 	/mob/living/simple_animal/hostile/retaliate/rogue/cavetroll = 4)
 
 /obj/structure/spawner/invisible/goblin
-	max_mobs = 2
+	max_mobs = 1
 	mob_types = list(
 	/mob/living/simple_animal/hostile/retaliate/rogue/goblin/cave = 3,		//archer
 	/mob/living/simple_animal/hostile/retaliate/rogue/goblin = 3)		//archer

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -341,7 +341,7 @@
 		qdel(src)
 		return
 	var/should_update = FALSE
-	if(amount > 6 MINUTES)
+	if(amount > 8 MINUTES)
 		C.visible_message(span_notice("The Goblin decomposes..."))
 		qdel(C)
 		/*
@@ -349,7 +349,7 @@
 			if(!B.skeletonized)
 				B.skeletonized = TRUE
 				should_update = TRUE*/
-	else if(amount > 3 MINUTES)
+	else if(amount > 4 MINUTES)
 		for(var/obj/item/bodypart/B in C.bodyparts)
 			if(!B.rotted)
 				B.rotted = TRUE
@@ -359,11 +359,11 @@
 				if(istype(T))
 					T.add_pollutants(/datum/pollutant/rot, 1)
 	if(should_update)
-		if(amount > 6 MINUTES)
+		if(amount > 8 MINUTES)
 			C.update_body()
 			qdel(src)
 			return
-		else if(amount > 3 MINUTES)
+		else if(amount > 4 MINUTES)
 			C.update_body()
 
 /////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Increases spawn times for simplemob spawners, reduces mob spawns on carbon mob spawners. Increases range at which carbon mob spawners won't spawn a mob due to a nearby player being present.

## Why It's Good For The Game

Goblin fort looked a bit too unforgiving, this should tone it down a bit.