### PR TITLE
Bard healing no longer heals the mindless

### DIFF
--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -97,8 +97,9 @@
 			soundloop.start()
 		for(var/mob/living/carbon/human/L in viewers(7))
 			L.add_stress(stressevent)
-			var/datum/status_effect/buff/healing/musicalhealing/heal_effect = L.apply_status_effect(/datum/status_effect/buff/healing/musicalhealing)
-			heal_effect.healing_on_tick = healthbonus
+			if(L.mind)
+				var/datum/status_effect/buff/healing/musicalhealing/heal_effect = L.apply_status_effect(/datum/status_effect/buff/healing/musicalhealing)
+				heal_effect.healing_on_tick = healthbonus
 	else
 		playing = FALSE
 		soundloop.stop()

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -97,7 +97,7 @@
 			soundloop.start()
 		for(var/mob/living/carbon/human/L in viewers(7))
 			L.add_stress(stressevent)
-			if(L.mind)
+			if(!issimple(L))
 				var/datum/status_effect/buff/healing/musicalhealing/heal_effect = L.apply_status_effect(/datum/status_effect/buff/healing/musicalhealing)
 				heal_effect.healing_on_tick = healthbonus
 	else

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -97,7 +97,7 @@
 			soundloop.start()
 		for(var/mob/living/carbon/human/L in viewers(7))
 			L.add_stress(stressevent)
-			if(!issimple(L))
+			if(L.mind)
 				var/datum/status_effect/buff/healing/musicalhealing/heal_effect = L.apply_status_effect(/datum/status_effect/buff/healing/musicalhealing)
 				heal_effect.healing_on_tick = healthbonus
 	else


### PR DESCRIPTION
## About The Pull Request

Adds a check for simplemobs.

## Why It's Good For The Game

Simplemobs can't be healed by this buff anyway, I think. This _will_ still make it heal more complex AI enemies, like static-spawned goblins, I think? But it's like half a point per second, it is not going to make the difference in a fight.
Original PR would make it check for a mind, but Vide insisted otherwise.

Edit 2: Okay Vide was talking about something else. Now it DOES check for a mind.