### PR TITLE
BUGFIX: Clerics can get their god's T1 magic again.

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -132,7 +132,7 @@
 	if(!H || !H.mind || !patron)
 		return
 
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/churn, patron.t0)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/churn, patron.t0, patron.t1)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue


### PR DESCRIPTION
## About The Pull Request

The game only checks if you've earned new magic when you advance into that tier or if it's explicitly given to you. Clerics start at tier 1 without being given the tier 1 spell, so they just... don't ever get it. This change gives clerics their t1 spell when they're given devotion at chargen.

## Why It's Good For The Game

Holy casters should get all of their god's spells, probably.
