### PR TITLE
Thief Diety spell re-flavoring and revival

### DIFF
--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -48,6 +48,7 @@
 	t1 = /obj/effect/proc_holder/spell/invoked/Joy_takes_flight
 	t2 = /obj/effect/proc_holder/spell/invoked/Laughing_god
 	t3 = /obj/effect/proc_holder/spell/invoked/Smokebomb
+	t4 = /obj/effect/proc_holder/spell/invoked/revive_inhumen/thief
 	confess_lines = list(
 		"I TAKE WITH SKILLED AND NIMBLE HANDS!",
 		"THIEFLORD'S GIFT CONSUME YOU!",

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -1,6 +1,6 @@
 // Xylixan
 /obj/effect/proc_holder/spell/invoked/Joy_takes_flight
-	name = "Joy takes flight"
+	name = "Steal Speed"
 	overlay_state = "Joy Takes Flight"
 	releasedrain = 30
 	chargedrain = 0
@@ -11,7 +11,7 @@
 	chargedloop = null
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/webspin.ogg'
-	invocation = "My trick is done, I'll speed from sight! I'll move so fast that joy takes flight!"
+	invocation = "Take my strength and grant me swiftness!"
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
@@ -28,7 +28,7 @@
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/Laughing_god
-	name = "Laughing god"
+	name = "Steal Time"
 	desc = ""
 	overlay_state = "Laughing God"
 	releasedrain = 30
@@ -39,7 +39,7 @@
 	movement_interrupt = FALSE
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/webspin.ogg'
-	invocation = "The Trickster skirts the edges of the rule, whilst witless louts are made to act the fool!"
+	invocation = "Take their time!"
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
@@ -49,22 +49,14 @@
 
 /obj/effect/proc_holder/spell/invoked/Laughing_god/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
-		if(prob(75))
-			var/mob/living/target = targets[1]
-			var/giggle_to_public = pick("[target] giggles!", "[target] struggles to not chuckle!", "[target] starts to laugh!", "[target] frowns, as if they don't get the joke")
-			var/giggle_to_target = pick("That is so funny!", "You start to giggle!", "Your mouth turns upwards in a smile!", "What a horrible thing to say...")
-			target.visible_message(span_warning("[giggle_to_public]"), span_warning("[giggle_to_target]"))
-			target.Stun(10)
-			target.Jitter(rand(5))
-			if(prob(66))
-				target.emote(pick("giggle","laugh","chuckle"))
-		else 
-			user.Stun(40) 
-			user.visible_message(span_userdanger("Looks like I am the fool..."))
-
+		var/mob/living/target = targets[1]
+		var/freeze_to_public = pick("[target] slows to a stop!", "[target] struggles to move!", "[target] freezes in place!")
+		var/freeze_to_target = pick("You can't seem to move!", "Your body fails you for a moment!", "Your muscles lock up!")
+		target.visible_message(span_warning("[freeze_to_public]"), span_warning("[freeze_to_target]"))
+		target.Stun(10)
 
 /obj/effect/proc_holder/spell/invoked/Smokebomb
-	name = "Smoke Bomb"
+	name = "Steal Sight"
 	overlay_state = "Smoke Bomb"
 	releasedrain = 30
 	chargedrain = 0
@@ -74,7 +66,7 @@
 	range = 0
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-	invocation = "The Trickster is a clever chap, it's time to hide under his cap!"
+	invocation = "Steal away their sight!"
 	invocation_type = "whisper"
 	sound = 'sound/misc/area.ogg'
 	associated_skill = /datum/skill/magic/holy

--- a/code/modules/spells/roguetown/acolyte/zizo.dm
+++ b/code/modules/spells/roguetown/acolyte/zizo.dm
@@ -134,3 +134,5 @@
 		return TRUE
 	return FALSE
 
+/obj/effect/proc_holder/spell/invoked/revive_inhumen/thief
+	name = "Steal Death"


### PR DESCRIPTION
## About The Pull Request

- All three spells given to The Thief have been re-flavored to theft instead of trickstery rhymes. Stealing speed (in exchange for strength), stealing a moment of the target's time (in the form of a tiny stun), or stealing everyone's sight (by making someone invisible). Flavor for invisibility might be confusing for the very first use (it looks about as much like a blindness spell), but it's the best I could come up with considering it's not self-cast only.
- Stun spell no longer has a 1/4th chance of stunning you for a fairly long time.
- Thief now gets the same unholy revival that the Snake does, at tier 4. Spell name is flavored to be "Stealing Death" from the target, but that's the only difference.

## Why It's Good For The Game

- Flavor text should match the god that's actually in the game, not the god that was in old lore whose direct correspondent isn't even the one getting the spells anymore.
- RNG that literally kills you if you try to use this spell in a fight. 10 tick stun is only really good for breaking grapples anyway - you know, something a thief would want the power to be able to do when a guard gets their hand on them. Eora's (or Viiritri's, whatever) Enthrall already does the same thing. I fear the day someone thinks the spell is too weak and makes the stun on it longer, though.
- Fantasy-Prometheus, who stole the power of the sun to give to mortals, is a much more fitting god to grant resurrection magic than the self-centered snake that only seeks to cause further entropy. What greater power to steal than the power over death? What greater heist than stealing souls from Yamais? However you want to look at it.

Noc and Xylix - Lune and Onder, are going to be substantially worse than the Thief after this (ignoring Lune handing out the magic tab to sufficiently devout roles because Lightning Lure is still incredibly stupid), but they're already substantially worse than the snake. I don't think the Thief is going to be any stronger than the snake, and I'm assuming that's the balance target of the obscure gods, even if the other two don't have spells at all yet.
I'll probably give Onder a wider spell selection in the future, though for the moment their god trait is very strong because I did not realize how strong bog trekking is when I remixed all the god boons. So hopefully they don't feel entirely useless as a potential cleric pick.