### PR TITLE
Darkvision update

### DIFF
--- a/code/modules/client/customizer/customizers/organ/eyes.dm
+++ b/code/modules/client/customizer/customizers/organ/eyes.dm
@@ -82,6 +82,13 @@
 	customizer_choices = list(/datum/customizer_choice/organ/eyes/elf)
 	default_choice = /datum/customizer_choice/organ/eyes/elf
 
+/datum/customizer_choice/organ/eyes/darkvision
+	organ_type = /obj/item/organ/eyes/darkvision
+
+/datum/customizer/organ/eyes/darkvision
+	customizer_choices = list(/datum/customizer_choice/organ/eyes/darkvision)
+	default_choice = /datum/customizer_choice/organ/eyes/darkvision
+
 /datum/customizer/organ/eyes/moth
 	customizer_choices = list(/datum/customizer_choice/organ/eyes/moth)
 	default_choice = /datum/customizer_choice/organ/eyes/moth

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -68,7 +68,7 @@
 		/datum/bodypart_feature/hair/facial,
 	)
 	customizers = list(
-		/datum/customizer/organ/eyes/darkvision,
+		/datum/customizer/organ/eyes/humanoid,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -68,7 +68,7 @@
 		/datum/bodypart_feature/hair/facial,
 	)
 	customizers = list(
-		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/organ/eyes/darkvision,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,

--- a/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
@@ -60,7 +60,7 @@
 		ORGAN_SLOT_HORNS = /obj/item/organ/horns,
 		)
 	customizers = list(
-		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/organ/eyes/darkvision,
 		/datum/customizer/bodypart_feature/hair/head/humanoid/bald_default,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid/shaved_default,
 		/datum/customizer/bodypart_feature/accessory,

--- a/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
@@ -65,7 +65,7 @@
 		/datum/bodypart_feature/hair/facial,
 	)
 	customizers = list(
-		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/organ/eyes/darkvision,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,

--- a/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
@@ -59,7 +59,7 @@
 		/datum/bodypart_feature/hair/facial,
 	)
 	customizers = list(
-		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/organ/eyes/darkvision,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,

--- a/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
@@ -57,7 +57,7 @@
 		/datum/bodypart_feature/hair/facial,
 	)
 	customizers = list(
-		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/organ/eyes/darkvision,
 		/datum/customizer/bodypart_feature/hair/head/humanoid/vulpkian,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -50,7 +50,7 @@
 	race_bonus = list(STAT_CONSTITUTION = 1)
 	enflamed_icon = "widefire"
 	customizers = list(
-		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/organ/eyes/darkvision,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -480,6 +480,8 @@
 	accessory_type = /datum/sprite_accessory/eyes/moth
 	eye_color = "000000"
 	second_color = "000000"
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	see_in_dark = 24
 
 /obj/item/organ/eyes/snail
 	name = "snail eyes"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -188,6 +188,12 @@
 	desc = ""
 	see_in_dark = 14
 
+/obj/item/organ/eyes/darkvision
+	name = "luminous eyes"
+	desc = ""
+	see_in_dark = 7
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+
 /obj/item/organ/eyes/halfelf
 	name = "half-elf eyes"
 	desc = ""
@@ -197,8 +203,8 @@
 /obj/item/organ/eyes/goblin
 	name = "goblin eyes"
 	desc = ""
-	see_in_dark = 15
-	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
+	see_in_dark = 24
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 
 ///Robotic
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Basically, certain species (Goblin, Tabaxi, Lupian, Fluvian, Kobold, and Vulpkanin) that SHOULD have some ability to see in the dark do not because their eyes are overwritten by customizer code. I have made it so that these species properly receive their night vision.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most of these species can only see to the edge of their screen in complete dark; a range of 7 tiles. Elves can see twice as far and have precise control over their darkvision, while Goblins and Fluvians can see as far as 24 tiles in the dark, though there may not be any way to take advantage of it at this time.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
