### PR TITLE
Partially reverts stealth nerf to Kneestingers spell

### DIFF
--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -100,7 +100,7 @@
 	associated_skill = /datum/skill/magic/holy
 	invocation = "Nature spirits, come to me.."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
-	devotion_cost = 300
+	devotion_cost = 60
 
 /obj/effect/proc_holder/spell/targeted/conjure_glowshroom/cast(list/targets, mob/user = usr)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Vide pulled a classic maneuver of nuking something they don't like hidden in a big commit. This time they raised Glowshroom cast cost from 30 devotion all the way to 300, three times as expensive as resurrection. This PR partially reverts to 60, half the original price.

## Why It's Good For The Game

Kneestingers are cancerous, I get that part, but not so cancerous that they need to blast half of your max devotion pool every time you use them. The 15 second vanish timer should prevent any mass grief from spamming them all over the place.
Not a full revert because they deserved a nerf in the first place, just not one to this extent.

Vide: Your nerfs to spells like this and invis wouldn't get reverted if you actually PR'd them instead of stealth committing. I've nuked Lightning Lure about as hard and it's stuck because I actually went through the PR process. Stop doing this shit.