### PR TITLE
Musician trait no longer gives default SS13 MIDI instruments

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -143,8 +143,8 @@ datum/quirk/fan_mime
 
 /datum/quirk/musician
 	name = "Musician"
-	desc = "I am good at playing music."
-	value = 1
+	desc = "I am good at playing music. I've also hidden a lute!"
+	value = 2
 	mob_trait = TRAIT_MUSICIAN
 	gain_text = span_notice("I know everything about musical instruments.")
 	lose_text = span_danger("I forget how musical instruments work.")
@@ -152,12 +152,8 @@ datum/quirk/fan_mime
 
 /datum/quirk/musician/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/choice_beacon/music/B = new(get_turf(H))
-	var/list/slots = list (
-		"backpack" = SLOT_IN_BACKPACK,
-		"hands" = SLOT_HANDS,
-	)
-	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/misc/music, 3, TRUE)
+	H.mind.special_items["Lute"] = /obj/item/rogue/instrument/lute
 
 /datum/quirk/night_vision
 	name = "Low Light Vision"


### PR DESCRIPTION
## About The Pull Request

Instead of giving an orbital supply beacon, you how hide a lute in a tree and gain 3 music skill when you take this perk. Cost is now also 2 in line with the other perks that increase skill and give an item.

## Why It's Good For The Game

Electric guitars probably do not exist in StoneHedge lore.
Music healing from this is not a practical balance concern - the way I scaled the initial PR, 30 seconds of journeyman healing is 1 second of cleric healing. Or more direct comparison: 1/5th of what actual bards can heal with music. You're not doing anything other than soothing very light bruises with this.
