### PR TITLE
BUGFIX: Cloistered Devouts and clerical Guildmaster gain all spells on spawn

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -180,7 +180,7 @@
 		return
 
 	granted_spells = list()
-	var/list/spelllist = list(patron.t0, patron.t1)
+	var/list/spelllist = list(patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
@@ -212,7 +212,7 @@
 		return
 
 	granted_spells = list()
-	var/list/spelllist = list(patron.t0)
+	var/list/spelllist = list(patron.t0, patron.t1, patron.t2)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue


### PR DESCRIPTION
## About The Pull Request

Devouts cannot gain spells through devotion _at all_ currently. This prevents that from being a problem by just giving them all the spells they could possibly gain.

## Why It's Good For The Game

Technically a lazy solution but they _should_ have all the magic they can get already. We're talking about highly-devoted monks here. And the Guildmaster who has an entire career behind him. I think I could fix the actual spell gain on them with a bit more effort but this makes more sense anyway.
This does not change less-holy clerics and templars, who work fine. They still have to earn their spells, as much as standing still for two minutes is earning something.