### PR TITLE
Proper balancing for nettles.

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -28,7 +28,7 @@
 		if(HAS_TRAIT(L, TRAIT_KNEESTINGER_IMMUNITY)) //Dendor kneestinger immunity
 			return TRUE
 
-		if(L.electrocute_act(30, src))
+		if(L.electrocute_act(10, src))
 			L.consider_ambush()
 			if(L.throwing)
 				L.throwing.finalize(FALSE)
@@ -42,7 +42,7 @@
 		var/mob/living/L = AM
 		if(L.z == z)
 			if(!HAS_TRAIT(L, TRAIT_KNEESTINGER_IMMUNITY))
-				if(L.electrocute_act(30, src))
+				if(L.electrocute_act(10, src))
 					L.emote("painscream")
 					L.update_sneak_invis(TRUE)
 					L.consider_ambush()
@@ -52,7 +52,7 @@
 	if(isliving(user) && W && user.z == z)
 		if(W.flags_1 & CONDUCT_1)
 			var/mob/living/L = user
-			if(L.electrocute_act(30, src)) // The kneestingers will let you pass if you worship dendor, but they won't take your stupid ass hitting them.
+			if(L.electrocute_act(5, src)) // The kneestingers will let you pass if you worship dendor, but they won't take your stupid ass hitting them.
 				L.emote("painscream")
 				L.consider_ambush()
 				if(L.throwing)


### PR DESCRIPTION
It's intention is to nerf the time that stun is applied from stinging nettles. Why? so that they can still be used in combat and to stun; but not as long. It should be more fun and less painful to cut or mitigate them as well.