### PR TITLE
Guildmaster now requires 10 PQ again

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -14,7 +14,7 @@
 
 	outfit = /datum/outfit/job/roguetown/veteran
 	give_bank_account = 1500
-	min_pq = 0
+	min_pq = 10
 	max_pq = null
 
 	cmode_music = 'sound/music/combat_guard.ogg'


### PR DESCRIPTION
## About The Pull Request

Adds a single digit to the Guildmaster's class file.

## Why It's Good For The Game

Test values should probably not be in the live game. 10 is the old value before this accidental change.
