### PR TITLE
The Wyld Magick;

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -40,27 +40,28 @@
 	cloak = /obj/item/clothing/cloak/raincloak/green
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
 	backpack_contents = list(
-		/obj/item/seeds/wheat = 1,
-		/obj/item/seeds/apple = 1,
-		/obj/item/seeds/shroom = 1,
-		/obj/item/seeds/sweetleaf = 1,
+		/obj/item/seeds/berryrogue = 1,
+		/obj/item/rogueweapon/whip = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/manapot = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot = 1,
 	)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)//Druids making herbal medicine/magical remedies
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/craft/tanning, 2, TRUE)//Added to represent survivalism skills. They can make hide goods enough to replenish their own armors.
 		H.mind.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/magic/druidic, 4, TRUE) //Allows you to craft briarmasks. Otherwise this does nothing, but maybe one day it will.
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/druidic, 4, TRUE) //Allows you to craft Briarmasks. Otherwise this does nothing, but maybe one day it will. Wouldn't mind tieng this to additional stuff like leaf capes and Upgraded Forestor Armor.
 		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 4, TRUE)//wildman can ungah bungah better now
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 4, TRUE)//Wildman can ungah bungah better now
 		if(H.age == AGE_OLD)
 			H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/magic/druidic, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -35,22 +35,22 @@
 /datum/outfit/job/roguetown/bogguardsman/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	head = /obj/item/clothing/head/roguetown/helmet/leather
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson
+	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
 	cloak = /obj/item/clothing/cloak/raincloak/green
 	neck = /obj/item/clothing/neck/roguetown/bervor
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/bog
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	beltl = /obj/item/flashlight/flare/torch/lantern
+	beltl = /obj/item/quiver/arrows
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/sword/silver/sabre/elf
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	id = /obj/item/scomstone
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/signal_horn = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1, /obj/item/signal_horn = 1, /obj/item/flashlight/flare/torch/lantern =1,)
 	if(H.mind)
 		assign_skills(H)
 	H.verbs |= /mob/proc/haltyell
@@ -58,21 +58,19 @@
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_WILD_EATER, TRAIT_GENERIC)
 
-/*Design philosophy: "Jack of all tades, master of.. few" - Peasent, so bow, axe, and polearm skill. Knows most combat skills, but other than those not great with them.
-Also given some non-combat skills that a peasent would have, just to support themselves, but not anything to replace soilsons with.*/
+/*Design philosophy: These are rangers and the closest concept to guards; Referred to as Hedge Knights for lore reason on dreamkeep. They can do medicine, archery and track the forests really well. They are also competent with daggers and swords and some wilderness skills to make use of aspects.*/
 /datum/outfit/job/roguetown/bogguardsman/proc/assign_skills(mob/living/carbon/human/H)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 4, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 4, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 3, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/alchemy, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/cooking, 1, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/labor/butchering, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 4, TRUE)
@@ -83,7 +81,9 @@ Also given some non-combat skills that a peasent would have, just to support the
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/masonry, 2, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/misc/tracking, 4, TRUE) //Hearthstone change.
+	H.mind.adjust_skillrank_up_to(/datum/skill/misc/tracking, 4, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/craft/tanning, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/misc/sewing, 1, TRUE) //So they can make leather and gambeson armors and slight alterations on their own as ranger-types.
 	H.change_stat("strength", 3)
 	H.change_stat("perception", 2)
 	H.change_stat("constitution", 2)

--- a/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
@@ -50,15 +50,14 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/quiver/Parrows
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1, /obj/item/signal_horn = 1, /obj/item/rope/chain =1, /obj/item/flashlight/flare/torch/lantern =1,)
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/bows, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
@@ -66,12 +65,13 @@
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 1, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 1, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/tracking, 4, TRUE) //Hearthstone change.
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE)	//Peasent levy, so some skill
-		H.mind.adjust_skillrank_up_to(/datum/skill/labor/farming, pick(1,2,2), TRUE)		//Peasent levy, so some skill
+		H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE) //Ranger background Flavor
+		H.mind.adjust_skillrank_up_to(/datum/skill/craft/tanning, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/sewing, 1, TRUE) //Ranger Background Flavor
 		H.change_stat("strength", 3)
 		H.change_stat("constitution", 2)
 		H.change_stat("perception", 2)


### PR DESCRIPTION
- changes out the old druid loadout that was focused on farming to have more thematic gear resembling their role better. They get a whip, potions and berry seeds. They also received tanning as a skill and received a buff to medicine at the loss of wrestleing skill, which still isn't as significant as the boost they received to crafting skills to incentivize them to survivalist players, too.

- fixes hedgeknight not spawning with a quiver or adequate armor, and similiarly added gear to both them and the hedgemaster + skills to give them more ranger flavor and make their isolated post more self-sufficient if they choose.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'm pretty much just boosting the loadouts and skills of these classes so they can perform better. Druids are now more reflective of the hybrid they are and feel pretty solid. Probably wont be updating them anymore for a while. 

The Hedgeknights and Hedgemasters needed some better gear and I might still add a better helmet option in future for them; but we're really looking towards buffing forester armor or making some metal variants for them at this stage. (Spriting to be done!)
