### PR TITLE
Youngmaster

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/grandmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/church/grandmaster.dm
@@ -75,17 +75,16 @@
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/rogueweapon/flail/sflail
-	r_hand = /obj/item/rogueweapon/sword/long
 	id = /obj/item/clothing/ring/silver
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 4, TRUE) // actual ass, but worse. Good luck.
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 5, TRUE) // Might be utterly disgusting. Good luck.
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/grandmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/church/grandmaster.dm
@@ -75,6 +75,7 @@
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/rogueweapon/flail/sflail
+	r_hand = /obj/item/rogueweapon/sword/long
 	id = /obj/item/clothing/ring/silver
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	neck = /obj/item/clothing/neck/roguetown/chaincoif

--- a/code/modules/jobs/job_types/roguetown/church/grandmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/church/grandmaster.dm
@@ -6,7 +6,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_patrons = ALL_CLERIC_PATRONS
-	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	outfit = /datum/outfit/job/roguetown/grandmaster
 	min_pq = 5
 	max_pq = null
@@ -22,7 +22,7 @@
 	..()
 	H.virginity = TRUE
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
-	neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+	wrists = /obj/item/clothing/neck/roguetown/psicross/astrata
 	cloak = /obj/item/clothing/cloak/templar/psydon
 	switch(H.patron.name)
 		if("Elysius")


### PR DESCRIPTION
## About The Pull Request

Removes age requirement on the Grandmaster role.
Puts the fallback divine symbol on his wrists instead of his neck, so it doesn't get deleted by the coif.
Gives him 5 flail and shield skill, lowers sword skill to 4.

## Why It's Good For The Game

- If the Guildmaster and Innkeep, explicitly retirees picking up a new career, can be adults instead of middle-aged, as can the Hedgemaster, another "lead guard" role, I don't see why the Grandmaster can't.
- Bug fix for gods without their own outfit. (Uncommon gods.)
- Starting skill for a weapon he doesn't have being higher than for the ones he does is weird. Was tempted to give him a sword but it's probably better for design if guard-type roles aren't issued lethal weapons, and aren't given skills that encourage sourcing lethal weapons. I might give town Paladins flails or maces instead of swords now that I'm thinking about it...