### PR TITLE
Engoodening of hedgeknight

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -203,7 +203,7 @@
 	force_wielded = 15
 	name = "hedgeknight stunmace"
 	icon_state = "stunmace0"
-	desc = "Upon closer inspection, this mace has kneestingers all throughout it, rather than being powered by a battery. Only the Hedgeknights themselves bear the fortitude to hold it."
+	desc = "Upon closer inspection, this mace has kneestingers growing all throughout it, rather than being powered by a battery. Only the Hedgeknights themselves bear the fortitude to hold it."
 	gripped_intents = null
 	w_class = WEIGHT_CLASS_NORMAL
 	possible_item_intents = list(/datum/intent/mace/strike/stunner, /datum/intent/mace/smash/stunner)
@@ -213,10 +213,18 @@
 	var/charge = 1000
 	var/on = FALSE
 
+/obj/item/rogueweapon/mace/stunmace/hedgeknight/pickup(mob/user)
+	. = ..()
+	var/mob/living/carbon/human/H = user
+	if(!HAS_TRAIT(H, TRAIT_SHOCKIMMUNE)) || if(HAS_TRAIT(H, TRAIT_RAVOX_CURSE))
+		to_chat(H, span_danger("As you grasp the hedgeknight mace, you touch its kneestingers and feel a powerful and excruciating shock radiate through your body!"))
+		H.electrocute_act(30, src)
+		H.Paralyze(10 SECONDS, ignore_canstun = TRUE)
+
 /obj/item/rogueweapon/mace/stunmace/hedgeknight/process()
 	var/mob/user = loc
 	if(istype(user))
-		if(!HAS_TRAIT(user, TRAIT_SHOCKIMMUNE)) || if(!HAS_TRAIT(user, TRAIT_RAVOX_CURSE))
+		if(!HAS_TRAIT(user, TRAIT_SHOCKIMMUNE)) || if(HAS_TRAIT(user, TRAIT_RAVOX_CURSE))
 			to_chat(user, span_danger("As you grasp the hedgeknight mace, you touch its kneestingers and feel a powerful and excruciating shock radiate through your body!"))
 			user.Paralyze(10 SECONDS, ignore_canstun = TRUE)
 	if(on)

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -146,6 +146,21 @@
 				if(istype(I))
 					I.afterchange()
 
+/obj/item/rogueweapon/mace/stunmace/hedgeknight/funny_attack_effects(mob/living/target, mob/living/user, nodmg)
+	. = ..()
+	if(on)
+		target.electrocute_act(15, src)
+		target.Paralyze(10 SECONDS)//STR maxxers cannot be reliably chained, so electrocution may be used as an alternative.
+		charge -= 25
+		if(charge <= 0)
+			on = FALSE
+			charge = 0
+			update_icon()
+			if(user.a_intent)
+				var/datum/intent/I = user.a_intent
+				if(istype(I))
+					I.afterchange()
+
 /obj/item/rogueweapon/mace/stunmace/update_icon()
 	if(on)
 		icon_state = "stunmace1"
@@ -231,7 +246,7 @@
 		charge--
 	else
 		if(charge < 1000)
-			charge++
+			charge += 25
 	if(charge <= 0)
 		on = FALSE
 		charge = 0

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -198,6 +198,43 @@
 		update_icon()
 		playsound(src, pick('sound/items/stunmace_toggle (1).ogg','sound/items/stunmace_toggle (2).ogg','sound/items/stunmace_toggle (3).ogg'), 100, TRUE)
 
+/obj/item/rogueweapon/mace/stunmace/hedgeknight
+	force = 15
+	force_wielded = 15
+	name = "hedgeknight stunmace"
+	icon_state = "stunmace0"
+	desc = "Upon closer inspection, this mace has kneestingers all throughout it, rather than being powered by a battery. Only the Hedgeknights themselves bear the fortitude to hold it."
+	gripped_intents = null
+	w_class = WEIGHT_CLASS_NORMAL
+	possible_item_intents = list(/datum/intent/mace/strike/stunner, /datum/intent/mace/smash/stunner)
+	wbalance = 0
+	minstr = 5
+	wdefense = 0
+	var/charge = 1000
+	var/on = FALSE
+
+/obj/item/rogueweapon/mace/stunmace/hedgeknight/process()
+	var/mob/user = loc
+	if(istype(user))
+		if(!HAS_TRAIT(user, TRAIT_SHOCKIMMUNE)) || if(!HAS_TRAIT(user, TRAIT_RAVOX_CURSE))
+			to_chat(user, span_danger("As you grasp the hedgeknight mace, you touch its kneestingers and feel a powerful and excruciating shock radiate through your body!"))
+			user.Paralyze(10 SECONDS, ignore_canstun = TRUE)
+	if(on)
+		charge--
+	else
+		if(charge < 1000)
+			charge++
+	if(charge <= 0)
+		on = FALSE
+		charge = 0
+		update_icon()
+		if(istype(user))
+			if(user.a_intent)
+				var/datum/intent/I = user.a_intent
+				if(istype(I))
+					I.afterchange()
+		playsound(src, pick('sound/items/stunmace_toggle (1).ogg','sound/items/stunmace_toggle (2).ogg','sound/items/stunmace_toggle (3).ogg'), 100, TRUE)
+
 /obj/item/rogueweapon/katar
 	slot_flags = ITEM_SLOT_HIP
 	force = 16

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -3,13 +3,13 @@
 	flag = BOGGUARD
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 10
-	spawn_positions = 10
+	total_positions = 6
+	spawn_positions = 6
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
-	tutorial = " You decided to protect the dream dales oneday, and you joined the hedgecademy within the rangers keep. Learning from the best you can muster, you're a certified monster hunter as much as you are a ranger and guard. Keeping these woodlands safe is your duty."
+	tutorial = "The origins of your order are as ancient as the land upon which Stonehedge is built. The first Hedge Knights were rangers, once devoted to Sylvarn but finding that the wilderness was often harsh and lacking for justice. Hedge Knights these days are employed by the Adventurers' Guild to protect the town from violators of the Five Laws, whether they be adventurers, bandits, peasants, or night creatures. Do not abandon the town or abuse the powers and trust vested in you, or they will surely be taken away."
 	display_order = JDO_TOWNGUARD
 	whitelist_req = FALSE
 	outfit = /datum/outfit/job/roguetown/bogguardsman
@@ -34,46 +34,49 @@
 
 /datum/outfit/job/roguetown/bogguardsman/pre_equip(mob/living/carbon/human/H)
 	. = ..()
-	head = /obj/item/clothing/head/roguetown/helmet/leather
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson
+	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/foresterarmor
 	cloak = /obj/item/clothing/cloak/raincloak/green
 	neck = /obj/item/clothing/neck/roguetown/bervor
-	gloves = /obj/item/clothing/gloves/roguetown/leather
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/bog
-	pants = /obj/item/clothing/under/roguetown/trou/leather
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	beltl = /obj/item/flashlight/flare/torch/lantern
+	gloves = /obj/item/clothing/gloves/roguetown/forestergauntlets
+	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+	pants = /obj/item/clothing/under/roguetown/chainlegs
+	shoes = /obj/item/clothing/shoes/roguetown/boots/forestershoes
+	beltl = /obj/item/quiver/arrows
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/rogueweapon/sword/silver/sabre/elf
+	beltr = /obj/item/rogueweapon/mace/stunmace/hedgeknight
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	id = /obj/item/scomstone
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/signal_horn = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver = 1, /obj/item/signal_horn = 1)
 	if(H.mind)
 		assign_skills(H)
 	H.verbs |= /mob/proc/haltyell
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_WILD_EATER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_SHOCKIMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_BLINDFIGHTING, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DARKVISION, TRAIT_GENERIC)
 
-/*Design philosophy: "Jack of all tades, master of.. few" - Peasent, so bow, axe, and polearm skill. Knows most combat skills, but other than those not great with them.
-Also given some non-combat skills that a peasent would have, just to support themselves, but not anything to replace soilsons with.*/
+/*Design philosophy: Protectors of Stonehedge, whose holy maces are the bane of any who violate the Guild's few laws. While they are not as physically strong as more conventional warriors, they are swift and their endurance is second to none.*/
 /datum/outfit/job/roguetown/bogguardsman/proc/assign_skills(mob/living/carbon/human/H)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 4, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 4, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 3, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 5, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/alchemy, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/cooking, 1, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 2, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 6, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/labor/butchering, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 4, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 3, TRUE)
@@ -84,8 +87,7 @@ Also given some non-combat skills that a peasent would have, just to support the
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/masonry, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/tracking, 4, TRUE) //Hearthstone change.
-	H.change_stat("strength", 3)
-	H.change_stat("perception", 2)
-	H.change_stat("constitution", 2)
-	H.change_stat("endurance", 2)
-	H.change_stat("speed", 1)
+	H.change_stat("perception", 4)
+	H.change_stat("constitution", 4)
+	H.change_stat("endurance", 4)
+	H.change_stat("speed", 2)

--- a/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
@@ -46,7 +46,7 @@
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
-	beltr = /obj/item/rogueweapon/sword/silver/sabre/elf
+	beltr = /obj/item/rogueweapon/mace/stunmace/hedgeknight
 	belt = /obj/item/storage/belt/rogue/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/quiver/Parrows
@@ -54,7 +54,7 @@
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
@@ -64,7 +64,7 @@
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/swimming, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 6, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/riding, 3, TRUE)
@@ -72,15 +72,19 @@
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE)	//Peasent levy, so some skill
 		H.mind.adjust_skillrank_up_to(/datum/skill/labor/farming, pick(1,2,2), TRUE)		//Peasent levy, so some skill
-		H.change_stat("strength", 3)
-		H.change_stat("constitution", 2)
-		H.change_stat("perception", 2)
-		H.change_stat("endurance", 2)
+		H.change_stat("constitution", 4)
+		H.change_stat("perception", 4)
+		H.change_stat("endurance", 4)
+		H.change_stat("speed", 2)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	H.verbs |= /mob/proc/haltyell
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_WILD_EATER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_SHOCKIMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_BLINDFIGHTING, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DARKVISION, TRAIT_GENERIC)
 
 /obj/effect/proc_holder/spell/self/convertrole/bog
 	name = "Recruit Hedgeknight"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -523,7 +523,7 @@
 	shock_damage *= siemens_coeff
 	if((flags & SHOCK_TESLA) && (flags_1 & TESLA_IGNORE_1))
 		return FALSE
-	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
+	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE) && !HAS_TRAIT(src, TRAIT_RAVOX_CURSE))//Minhur's ire will make even a Hedgeknight vulnerable to the justice of their fellows
 		return FALSE
 	if(shock_damage < 1)
 		return FALSE

--- a/strings/laws_of_the_land.json
+++ b/strings/laws_of_the_land.json
@@ -5,7 +5,7 @@
 			"laws": [
 				"Settle your scores outside of town. Self defense and sparring are permitted by this law, but any combat between adventurers in Stonehedge that takes place outside of the training field may result in the arrest of all participants. The aggressor(s) shall then be imprisoned for one dae.",
 				"Keep your spells and appendages to yourself. Outside of providing medical assistance, removal of another's personal effects without permission will be punished with imprisonment of 1 dae OR a fine equal to the value of stolen or destroyed property, if it is not recovered.",
-				"To falsely apprehend or imprison a resident of Stonehedge or a member of the Guild in good standing will be punished with imprisonment of two daes.",
+				"To falsely apprehend or imprison a resident of Stonehedge or a member of the Guild in good standing will be punished with imprisonment of two daes. Those found to be Outlaws with no reported crimes may be fined no more than 25 mammon.",
 				"To force oneself upon a person sexually within the borders of Stonehedge or in view of its walls will be punished with two daes imprisonment and surgical removal of reproductive organs.",
 				"To unjustly take the life of another person or obstruct their revival is punishable by summary execution. To interfere with a lawful execution or the dignified burial of the executed is to invite the same punishment.",
 				"Hedge Knights and the Hedgemaster shall keep accurate records of any arrests including the name(s) of the apprehended, the crimes for which they are accused, any evidence collected, and any sentence carried out.",

--- a/strings/laws_of_the_land.json
+++ b/strings/laws_of_the_land.json
@@ -1,68 +1,15 @@
 {
 	"lawsets": {
-		"ten_commandments": {
-			"name": "The Ten Commandments",
+		"five_laws": {
+			"name": "The Laws of Stonehedge",
 			"laws": [
-				"Thou shalt have no other gods before me.",
-				"Thou shalt not make unto thee any graven image, or any likeness of any thing that is in heaven above, or that is in the earth beneath, or that is in the water under the earth.",
-				"Thou shalt not take the name of the Lord thy God in vain; for the Lord will not hold him guiltless that taketh his name in vain.",
-				"Remember the sabbath day, to keep it holy. Six days shalt thou labour, and do all thy work: But the seventh day is the sabbath of the Lord thy God: in it thou shalt not do any work, thou, nor thy son, nor thy daughter, thy manservant, nor thy maidservant, nor thy cattle, nor thy stranger that is within thy gates.",
-				"Honour thy father and thy mother: that thy days may be long upon the land which the Lord thy God giveth thee.",
-				"Honour thy father and thy mother: that thy days may be long upon the land which the Lord thy God giveth thee.",
-				"Thou shalt not commit adultery.",
-				"Thou shalt not steal.",
-				"Thou shalt not bear false witness against thy neighbour.",
-				"Thou shalt not covet thy neighbour's house, thou shalt not covet thy neighbour's wife, nor his manservant, nor his maidservant, nor his ox, nor his ass, nor any thing that is thy neighbors."
-			],
-			"weight": 3
-		},
-		"code of hammurabi": {
-			"name": "Code of Hamurabi",
-			"laws": [
-				"If a man put out the eye of another man, his eye shall be put out.",
-				"If any one is committing a robbery and is caught, then he shall be put to death.",
-				"If a man has betrothed a bride to his son and his son has known her, and if afterwards he (the father) lies in her bosom, and they seize him, this man shall be put to death; the woman shall go free.",
-				"If a builder builds a house for a man and does not make its construction firm, and the house which he has built collapses and causes the death of the owner of the house, that builder shall be put to death.",
-				"If any one take over a field to till it as a renter, he shall pay the corn rent of the field to its owner.",
-				"If any one place his property with another for safekeeping, and there at the place of safekeeping the property be lost, the owner of the house shall make restitution to the owner for the property that was lost.",
-				"If any one take a male or female slave of the court, or a male or female slave of a freed man, outside the city gates, he shall be put to death.",
-				"If a son strike his father, his hands shall be hewn off.",
-				"If any one be too lazy to maintain his dam and does not strengthen it, and a break be made in his dam and the water flood the plantation, the man in whose dam the break has been made shall replace the grain which he has caused to be ruined.",
-				"If any one steal cattle or sheep, or an ass, or a pig or a goat, if it belong to a god or to the court, the thief shall pay thirtyfold; if they belonged to a freed man of the king he shall pay tenfold; if the thief has nothing with which to pay he shall be put to death."
-			],
-			"weight": 1
-		},
-		"asimov": {
-			"name": "The Three Laws of Aasimar",
-			"laws": [
-				"A peasant may not injure a noble or, through inaction, allow a noble to come to harm.",
-				"A peasant must obey the orders given it by nobles except where such orders would conflict with the First Law.",
-				"A peasant must protect their own existence as long as such protection does not conflict with the First or Second Law."
-			],
-			"weight": 2
-		},
-		"bill_of_rights": {
-			"name": "Bill of Rights",
-			"laws": [
-				"Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.",
-				"A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.",
-				"No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.",
-				"The right of the people to be secure in their persons, houses, papers, and effects,[a] against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.",
-				"No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.",
-				"In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.",
-				"In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved, and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.",
-				"Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.",
-				"The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.",
-				"The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people."
-			],
-			"weight": 1
-		},
-		"human_supremacy": {
-			"name": "Humen Supremacy",
-			"laws": [
-				"Thou shalt not be inhumen. All that is inhumen is lesser.",
-				"Thou shalt not associate with lesser beings, humens that do so forsake their humenity.",
-				"Lesser beings must be exterminated."
+				"Settle your scores outside of town. Self defense and sparring are permitted by this law, but any combat between adventurers in Stonehedge that takes place outside of the training field may result in the arrest of all participants. The aggressor(s) shall then be imprisoned for one dae.",
+				"Keep your spells and appendages to yourself. Outside of providing medical assistance, removal of another's personal effects without permission will be punished with imprisonment of 1 dae OR a fine equal to the value of stolen or destroyed property, if it is not recovered.",
+				"To falsely apprehend or imprison a resident of Stonehedge or a member of the Guild in good standing will be punished with imprisonment of two daes.",
+				"To force oneself upon a person sexually within the borders of Stonehedge or in view of its walls will be punished with two daes imprisonment and surgical removal of reproductive organs.",
+				"To unjustly take the life of another person or obstruct their revival is punishable by summary execution. To interfere with a lawful execution or the dignified burial of the executed is to invite the same punishment.",
+				"Hedge Knights and the Hedgemaster shall keep accurate records of any arrests including the name(s) of the apprehended, the crimes for which they are accused, any evidence collected, and any sentence carried out.",
+				"Evidence in the form of eyewitness testimony may only be admitted in the form of sworn affidavit, written upon paper and signed by its author. False testimony shall result in serving out the same punishment as the accused."
 			],
 			"weight": 1
 		}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Currently, Hedgeknights are not at all equipped to enforce Stonehedge's laws. It is all too easy to outnumber and overwhelm them. This PR changes that. If you break the laws in Stonehedge and there are Hedgeknights around to enforce them, do not expect to win an honest fight.

Likewise, if you play Hedgeknight or Hedgemaster in bad faith, to abuse their advantages for fragging, for griefing, or solely to punish people for taking certain quirks instead of honest enforcement of the laws, you will be cursed and rolebanned. Exercise discretion and make Stonehedge a better place.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having actual laws to follow and guards who are actually well-equipped to enforce them may help cut down on vigilante justice, at least within the town limits. Also in the works for a future PR will be expansion on the investigative capabilities of Gravesingers and Wytchers and the addition of a respawn timer, which may be bypassed if the corpse is buried with any coin, giving them the toll to pay the carriage for immediate passage.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
