### PR TITLE
Grenzel mercs get trained for the armor they spawn in

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/Classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/Classes/grenzelhoft.dm
@@ -82,4 +82,5 @@
 
 	backpack_contents = list(/obj/item/roguekey/mercenary)
 
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

Medium armor training. They still have heavy training, if they can source it.

## Why It's Good For The Game

Being trained in the armor you spawn in is good.
Grenzels are the closest thing to heavy infantry on the mercenary list and should be the mercs you hire if you want some big guys in big armor, even if the employer has to be the one to supply it. (If only we actually had people hiring mercenaries on this server...)