### PR TITLE
General Sweeping and a bit of Wild Magick (Revised)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/bladesinger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/bladesinger.dm
@@ -6,7 +6,7 @@
 		/datum/species/elf/dark,
 		/datum/species/elf/wood,
 	)
-	maximum_possible_slots = 2
+	maximum_possible_slots = 5
 	traits_applied = list(TRAIT_MEDIUMARMOR)
 	category_tags = list(CTAG_ADVENTURER)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/cavalry.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/cavalry.dm
@@ -1,11 +1,11 @@
 /datum/advclass/cavalry
-	name = "Cavalry" // Medium armor fighter, melee-focused, expert at 1 weapon + some wrestling proefficiency, mediocre at rest. 
+	name = "Cavalry" // Medium armor fighter, melee-focused, expert at 1 weapon + some wrestling proefficiency, mediocre at rest.
 	tutorial = "You wandered off from your home seeking adventure, roaming to greener pastures for honor and chilvalry. You became an instrument of war, sitting atop a saiga, weapon and shield in hand! What will await here?"
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	outfit = /datum/outfit/job/roguetown/adventurer/cavalry
-	maximum_possible_slots = 4 // Seems like an OK number??? May remove cap otherwise but lower pick prob too
+	maximum_possible_slots = 5 // Seems like an OK number??? May remove cap otherwise but lower pick prob too
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED)
 	category_tags = list(CTAG_ADVENTURER)
 	cmode_music = 'sound/music/combat_cavalry.ogg' // Spanish guitars fuck, don't @ me
@@ -19,7 +19,7 @@
 	var/classchoice = input("Choose your path", "Available archetypes","Who are you, really?") as anything in classes
 
 	switch(classchoice)
-	
+
 		if("Cataphract")
 			H.set_blindness(0)
 			to_chat(H, span_warning("Some call you a madman. Others, an idiot. Yet you ride on, with your spear in one hand, and your shield in the other. When life itself seems lunatic, who knows where madness lies?"))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -5,7 +5,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	outfit = /datum/outfit/job/roguetown/adventurer/knighterrant
-	maximum_possible_slots = 3		//For testing!
+	maximum_possible_slots = 10		//For testing!
 	category_tags = list(CTAG_ADVENTURER)
 
 
@@ -24,7 +24,7 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	backl = /obj/item/rogueweapon/shield/tower
 	backr = /obj/item/rogueweapon/sword/iron/short
-		
+
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 1, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/pirate.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/pirate.dm
@@ -8,7 +8,7 @@
 	allowed_races = RACES_ALL_KINDSPLUS
 	outfit = /datum/outfit/job/roguetown/adventurer/pirate
 	category_tags = list(CTAG_ADVENTURER)
-	maximum_possible_slots = 5
+	maximum_possible_slots = 10
 	cmode_music = 'sound/music/combat_pirate.ogg'
 
 /datum/outfit/job/roguetown/adventurer/pirate

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
@@ -9,8 +9,8 @@
 		/datum/species/elf/wood,
 	)
 	outfit = /datum/outfit/job/roguetown/adventurer/sentinal
-	maximum_possible_slots = 5
-	pickprob = 50
+	maximum_possible_slots = 10
+	pickprob = 100
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_DODGEEXPERT, TRAIT_BOG_TREKKING, TRAIT_PERFECT_TRACKER)
 	category_tags = list(CTAG_ADVENTURER)
 

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -28,22 +28,22 @@
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/boots/forestershoes
 	pants = /obj/item/clothing/under/roguetown/loincloth/brown
-	belt = /obj/item/storage/belt/rogue/leather/rope
+	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/rogueweapon/sickle
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/wise
 	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
+	wrist = /obj/item/clothing/wrists/roguetown/bracers/leather
 	neck = /obj/item/clothing/neck/roguetown/psicross/dendor
 	gloves = /obj/item/clothing/gloves/roguetown/forestergauntlets
-	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
-	cloak = /obj/item/clothing/cloak/raincloak/green
+	cloak = /obj/item/clothing/cloak/templar/dendor
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
 	backpack_contents = list(
-		/obj/item/seeds/wheat = 1,
-		/obj/item/seeds/apple = 1,
-		/obj/item/seeds/shroom = 1,
-		/obj/item/seeds/sweetleaf = 1,
+		/obj/item/rope = 1,
+		/obj/item/clothing/neck/roguetown/psicross/silver = 1,
+		/obj/item/rogueweapon/whip = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot = 1,
 	)
 	if(H.mind)
@@ -54,6 +54,9 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/craft/cooking, 1, TRUE)// added so they can cook meals in the wild slightly more from the start.
+		H.mind.adjust_skillrank_up_to(/datum/skill/craft/tanning, 2, TRUE)// added so they can make leather goods.
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/sewing, 1, TRUE)// added so they can make light cloth goods etc, similiar to why rangers have it.
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -34,7 +34,7 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/wise
 	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
-	wrist = /obj/item/clothing/wrists/roguetown/bracers/leather
+	var/wrist = /obj/item/clothing/wrists/roguetown/bracers/leather
 	neck = /obj/item/clothing/neck/roguetown/psicross/dendor
 	gloves = /obj/item/clothing/gloves/roguetown/forestergauntlets
 	cloak = /obj/item/clothing/cloak/templar/dendor

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -3,8 +3,8 @@
 	flag = MONK
 	department_flag = CHURCHMEN
 	faction = "Station"
-	total_positions = 10
-	spawn_positions = 10
+	total_positions = 0
+	spawn_positions = 0
 
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_patrons = ALL_DIVINE_PATRONS

--- a/code/modules/jobs/job_types/roguetown/church/mortician.dm
+++ b/code/modules/jobs/job_types/roguetown/church/mortician.dm
@@ -14,7 +14,7 @@
 	outfit = /datum/outfit/job/roguetown/undertaker
 	display_order = JDO_GRAVEMAN
 	give_bank_account = TRUE
-	min_pq = -5
+	min_pq = 15
 	max_pq = null
 
 /datum/outfit/job/roguetown/undertaker

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/foresterarmor
-	cloak = /obj/item/clothing/cloak/raincloak/green
+	cloak = /obj/item/clothing/cloak/templar/dendor
 	neck = /obj/item/clothing/neck/roguetown/bervor
 	gloves = /obj/item/clothing/gloves/roguetown/forestergauntlets
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
@@ -50,7 +50,7 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	id = /obj/item/scomstone
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver = 1, /obj/item/signal_horn = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver = 1, /obj/item/signal_horn = 1, /obj/item/rope =1)
 	if(H.mind)
 		assign_skills(H)
 	H.verbs |= /mob/proc/haltyell
@@ -84,9 +84,11 @@
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/riding, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE)
-	H.mind.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 2, TRUE)//Forester Armor remaking
 	H.mind.adjust_skillrank_up_to(/datum/skill/craft/masonry, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/tracking, 4, TRUE) //Hearthstone change.
+	H.mind.adjust_skillrank_up_to(/datum/skill/craft/tanning, 2, TRUE)// added so they can make/renew armor basics of leather
+	H.mind.adjust_skillrank_up_to(/datum/skill/misc/sewing, 2, TRUE)//added so they can make/renew armor and gear basics of gambeson or bandages
 	H.change_stat("perception", 4)
 	H.change_stat("constitution", 4)
 	H.change_stat("endurance", 4)

--- a/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
@@ -36,21 +36,22 @@
 
 /datum/outfit/job/roguetown/bogmaster/pre_equip(mob/living/carbon/human/H)
 	. = ..()
-	head = /obj/item/clothing/head/roguetown/helmet/leather
+	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
 	pants = /obj/item/clothing/under/roguetown/chainlegs
-	cloak = /obj/item/clothing/cloak/raincloak/green
+	cloak = /obj/item/clothing/cloak/templar/dendor
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half
 	neck = /obj/item/clothing/neck/roguetown/bervor
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/chain
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/footmangreaves
 	beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 	beltr = /obj/item/rogueweapon/mace/stunmace/hedgeknight
 	belt = /obj/item/storage/belt/rogue/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/quiver/Parrows
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1)
+	id = /obj/item/scomstone
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1, /obj/item/signal_horn = 1, /obj/item/rope/chain = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)


### PR DESCRIPTION
Loadout changes for: druid, hedgeknight/Hedgemaster (giving them the sylvan stuff and otherwise enhancing whats already there. Druids have their seedbank nerfed in exchange for lifting them out of the muck and into a role that can opt to bless crops but exists moreso for forest spirituality and law matters.

Increased the PQ for mortician to 15. I understand it was originally intended to 'redeem' PQ deficits but not any more.

Monk was removed because the role doesn't even do what people think it does.

probability and job slots have been increased to the other dm's touched.
