### PR TITLE
Un-armors warlocks, nerfs trickster rogues, allows the codebase to compile

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -30,7 +30,6 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	advjob_examine = TRUE
 	always_show_on_latechoices = TRUE
 	job_reopens_slots_on_death = TRUE
-	grant_lit_torch = FALSE
 
 /datum/job/roguetown/adventurer/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -39,9 +39,13 @@
 
 	//sleep(1)
 	//testing("[H] spawn troch")
+
+/* // This is what put the torch in adventurers' hands, causing the spam
 	var/obj/item/flashlight/flare/torch/T = new()
 	T.spark_act()
 	H.put_in_hands(T, forced = TRUE)
+*/
+
 	//framework for being able to list spells instead of individually input them
 	var/list/skills
 	var/list/roundstart_experience

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -153,7 +153,7 @@
 		cloak = /obj/item/clothing/cloak/raincloak/furcloak
 		shoes = /obj/item/clothing/shoes/roguetown/boots
 	// HEARTHSTONE ADD: cloistered devout custom outfits
-	else if (classchoice == "Cloistered Devout")
+	else if (classchoice == "Temple Devout")
 		// do the generic stuff first then replace it w/ patron specific things... if it exists
 		// for reference, cloistered devouts are lightly armored/unarmored but get patron-specific stuff (if applicable) and a devo regen
 		head = /obj/item/clothing/head/roguetown/roguehood/black
@@ -201,7 +201,7 @@
 	// HEARTHSTONE ADDITION END
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	// HEARTHSTONE ADDITION: cloistered devout devo regen & tier buff
-	if (classchoice == "Cloistered Devout")
+	if (classchoice == "Temple Devout")
 		if(H.patron?.type == /datum/patron/divine/noc)
 			C.grant_spells_devout_noc(H)
 		else

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -226,8 +226,10 @@
 	H.change_stat("intelligence", 3)
 	H.visible_message(span_info("I’m not just a thief. I'm a master of illusion and deception. One moment, I'm a harmless vagabond. The next, I'm a blur of motion, leaving my pursuers bewildered and outwitted."))
 	H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)
+	/*
 	if(H.mind)
 		H.mind.adjust_spellpoints(3)
+	*/ // Brings them down to arcanist bard levels of spell-points. Lets not have them be better spellcasters than warlocks
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/rogue_knock)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -319,7 +319,10 @@
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	belt = /obj/item/storage/belt/rogue/leather
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson // Armor downgrade from hauberk to gambeson
+	if(H.gender == MALE)
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	else 
+		shirt = /obj/item/clothing/suit/roguetown/armor/armordress // Armor downgrade from hauberk to gambeson
 	beltl = /obj/item/rogueweapon/huntingknife
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -70,7 +70,8 @@
 		"love", //ring of soulbinding
 		"friendship", //Pact of the Chain
 		"power", //empowered eldritch blast
-		"purpose" //Pact of the Star Chain
+		"purpose", //Pact of the Star Chain
+		"revenge" //give curse
 	)
 
 	var/boonchoice = input("What did you sell your faith for?", "Available boons") as anything in boons
@@ -128,6 +129,7 @@
 
 	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/mage
+	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	r_hand = /obj/item/rogueweapon/woodstaff
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	belt = /obj/item/storage/belt/rogue/leather/rope
@@ -149,18 +151,21 @@
 	H.visible_message(span_info("I made a deal with an archseelie from the wild."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/celestialpatron(mob/living/carbon/human/H, patronchoice)
-	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	// armor = /obj/item/clothing/suit/roguetown/armor/chainmail
+	if(H.gender == MALE)
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	else 
+		shirt = /obj/item/clothing/suit/roguetown/armor/armordress
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	pants = /obj/item/clothing/under/roguetown/trou/leather
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	pants = /obj/item/clothing/under/roguetown/tights/random
+	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/rogueweapon/mace
+	r_hand = /obj/item/rogueweapon/spear
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife)
 
 	//caster stats (must be 5 stat point total)
@@ -190,7 +195,7 @@
 		head = /obj/item/clothing/head/roguetown/fisherhat
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor
 	cloak = /obj/item/clothing/cloak/raincloak/yellow
-	gloves = /obj/item/clothing/gloves/roguetown/plate/zybantinegauntlets
+	// gloves = /obj/item/clothing/gloves/roguetown/plate/zybantinegauntlets // No plate gloves for you
 	wrists = /obj/item/rope
 	r_hand = /obj/item/rogueweapon/pitchfork
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
@@ -314,20 +319,7 @@
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	belt = /obj/item/storage/belt/rogue/leather
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
-	if(prob(70))
-		armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
-	else if(prob(50))
-		armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
-	else
-		armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
-	if(prob(20))
-		mask = /obj/item/clothing/mask/rogue/facemask
-	else if(prob(60))
-		head = /obj/item/clothing/head/roguetown/helmet/leather
-	else if(prob(20))
-		head = /obj/item/clothing/head/roguetown/helmet/skullcap
-	else
-		head = /obj/item/clothing/head/roguetown/helmet/kettle
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson // Armor downgrade from hauberk to gambeson
 	beltl = /obj/item/rogueweapon/huntingknife
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 
@@ -349,40 +341,27 @@
 	H.visible_message(span_info("I made a deal with a sentient weapon."))
 
 /datum/outfit/job/roguetown/adventurer/warlock/proc/undeadpatron(mob/living/carbon/human/H, patronchoice)
-	H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
+	H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
 
-	if(prob(20))
-		head = /obj/item/clothing/head/roguetown/knitcap
-	else
-		head = null
-	if(prob(10))
-		cloak = /obj/item/clothing/cloak/raincloak/brown
-	else
-		cloak = null
-	if(prob(10))
-		gloves = /obj/item/clothing/gloves/roguetown/fingerless
-	else
-		gloves = /obj/item/clothing/gloves/roguetown/brigandinegauntlets
-		armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
-		pants = /obj/item/clothing/under/roguetown/tights/vagrant
-		if(prob(50))
-			pants = /obj/item/clothing/under/roguetown/tights/vagrant/l
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
-		if(prob(50))
-			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant/l
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	cloak = /obj/item/clothing/cloak/raincloak/brown
+	gloves = /obj/item/clothing/gloves/roguetown/angle
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+	pants = /obj/item/clothing/under/roguetown/tights/random
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
+	wrists = /obj/item/clothing/wrists/roguetown/vambraces
 	neck = /obj/item/clothing/neck/roguetown/gorget
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armoriron
+	head = /obj/item/clothing/head/roguetown/helmet/ironpothelmet
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/rogueweapon/mace
-	backl = /obj/item/rogueweapon/sword/iron/short
-
+	beltl = /obj/item/rogueweapon/sword/iron/short
+	backl = /obj/item/rogueweapon/shield/tower
+	// They're the tank subclass, so I'm keeping their armor in. If it's a problem, it's pretty easy to comment it out and give them hauberks instead
 	//tank stats (must be 5 stat point total)
 	H.change_stat("strength", 1)
 	H.change_stat("endurance", 2)
@@ -392,7 +371,7 @@
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/infestation5e)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/chilltouch5e) // decay-themed magic and a skeletal hand to attack people with
 
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	// ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC) // Unnecessary with the heavy armor trait
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -570,6 +570,7 @@
 	craftdiff = 3
 	sellprice = 12
 
+/* // These are plate-level gloves and boots, and have their own smithing recipe.
 /datum/crafting_recipe/roguetown/sewing/zybantinegauntlets
 	name = "zybantine gauntlets"
 	result = list(/obj/item/clothing/gloves/roguetown/plate/zybantinegauntlets)
@@ -583,6 +584,7 @@
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 4
+*/
 
 /datum/crafting_recipe/roguetown/sewing/stockdress
 	name = "dress"

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -36,6 +36,7 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	ADD_TRAIT(H, TRAIT_NOHUNGER, QUIRK_TRAIT)
 	ADD_TRAIT(H, TRAIT_NOBREATH, QUIRK_TRAIT)
+	ADD_TRAIT(H, TRAIT_NOSLEEP, QUIRK_TRAIT)
 	H.change_stat("endurance", 1)
 
 /datum/quirk/deadened
@@ -289,6 +290,7 @@
 	H.grant_language(/datum/language/orcish)
 	H.grant_language(/datum/language/beast)
 	H.grant_language(/datum/language/draconic)
+	H.grant_language(/datum/language/faexin)
 
 /datum/quirk/civilizedbarbarian
 	name = "Tavern Brawler"
@@ -586,11 +588,11 @@
 	ADD_TRAIT(H, TRAIT_PACIFISM, QUIRK_TRAIT)
 
 
-/datum/quirk/pacifist
+/datum/quirk/endowed
 	name = "Endowment Curse"
 	desc = "I was cursed with endowment... This makes life hard."
 	value = -2
 
-/datum/quirk/pacifist/on_spawn()
+/datum/quirk/endowed/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	ADD_TRAIT(H, TRAIT_ENDOWMENT, QUIRK_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the compile error while still doing the thing it was supposed to do

De-armors some warlock classes (Keeping undead warlocks armored for the moment, but can change it if needed)

Fixes Temple Devout clerics

Nerfs arcane trickster rogues