### PR TITLE
Add pocket sand

### DIFF
--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -74,6 +74,25 @@
 	icon_state = "oresand"
 	smeltresult = /obj/item/ingot/glass
 	sellprice = 4
+
+// pocket sand!!
+// copied from /obj/item/stack/ore/glass/throw_impact
+/obj/item/rogueore/sand/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	if(..() || !ishuman(hit_atom))
+		return
+	// 20% chance if thrown by an explosion or something, otherwise thrower must have targeted head
+	if((isnull(throwingdatum?.target_zone) && prob(80)) || ran_zone(throwingdatum?.target_zone) != BODY_ZONE_HEAD)
+		return
+	var/mob/living/carbon/human/humie = hit_atom
+	if(humie.is_eyes_covered())
+		humie.visible_message(span_danger("[humie]'s eye protection blocks the sand!"), span_warning("My eye protection blocks the sand!"))
+		return
+	humie.adjust_blurriness(6)
+	humie.adjustStaminaLoss(15)//the pain from my eyes burning does stamina damage
+	humie.confused += 5
+	to_chat(humie, span_danger("\The [src] gets into my eyes! The pain, it burns!"))
+	qdel(src)
+
 /obj/item/rogueore/cinnabar
 	name = "cinnabar"
 	desc = "Red gems that contain the essence of quicksilver."


### PR DESCRIPTION
ports pocket sand from base SS13 sand to Roguetown sand type as requested in #help by Fudgy. it also requires you to be targeting head and has a 20% chance to select a different zone (and a 17/18 chance to select something other than the head), resulting in around a 19% chance to miss. this can easily be adjusted of course
\- ophelia