### PR TITLE
Makes filling_organ reagent caps change with organ sizes

### DIFF
--- a/code/modules/surgery/organs/filling_organ.dm
+++ b/code/modules/surgery/organs/filling_organ.dm
@@ -52,7 +52,7 @@
 	//updates size caps
 	if(!issimple(H) && H.mind)
 		var/athletics = H.mind?.get_skill_level(/datum/skill/misc/athletics)
-		var/captarget = max_reagents+(athletics*4)
+		var/captarget = max_reagents+(athletics*4)+(5+storage_per_size+(storage_per_size*organ_size)) // Updates the max_reagents in case the organ size changes
 		if(damage)
 			captarget -= damage
 		if(contents.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes the organs' maximum reagent cap change when the organ changes in size, along with athletics skill (that part was already there).

Sorta buffs the endowment quirk, since they can now hold a whole lotta milk in them jugs.