### PR TITLE
Expansion of Gravesinger, Part 1

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -41,6 +41,7 @@
 #define TRAIT_SEEDKNOW "Seed Knower"
 #define TRAIT_GOODRUNNER "Good Runner"
 #define TRAIT_TINY "Tiny"
+#define TRAIT_SEESPIRITS "Spectral Sight"
 // ROGUEspecialTRAITS (description when rmb skills button)
 #define TRAIT_CIVILIZEDBARBARIAN "Tavern Brawler"
 #define TRAIT_COMICSANS "Annoying Face"
@@ -195,7 +196,6 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_FIENDKISS = "When I cast projectile magic, the fiend also hurls a fire bolt at the same location.", // Hearthstone change
 	TRAIT_CHARGER = "I can charge into people like a ram.", // Hearthstone change
 	TRAIT_ARTIFICER = "I can use gems to improve items.", // Hearthstone change
-
 	TRAIT_BOG_TREKKING = "Expert in navigating these lands.", // Hearthstone change
 	TRAIT_GOODRUNNER = span_info("I can run without breaking a sweat!"),
 	TRAIT_NUDE_SLEEPER = span_warning("I can't fall asleep unless I'm nude and in bed."),
@@ -204,6 +204,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_NIGHT_VISION = span_info("Whether because of my species, my career choice, or by some boon of my patron, my eyes have adapted to see well in the dark."),
 	TRAIT_SUPER_NV = span_info("My ability to see in the dark extends further than that of most others, and I can consciously control how bright my surroundings appear to me."),
 	TRAIT_BLINDFIGHTING = span_info("I have an incredible sense of awareness, allowing me to dodge and parry attacks even when I can't see them coming, If i am in high awareness, I can even prevent sneak attacks."),
+	TRAIT_SEESPIRITS = span_necrosis("My eyes peer beyond the veil of life and death, allowing me to perceive spirits."),
 ))
 
 // trait accessor defines

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(treasury)
 	wait = 1
 	priority = FIRE_PRIORITY_WATER_LEVEL
 	var/tax_value = 0.11
-	var/queens_tax = 0.15
+	var/queens_tax = 0.2
 	var/treasury_value = 0
 	var/list/bank_accounts = list()
 	var/list/stockpile_datums = list()

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -178,8 +178,7 @@
 	break_sound = 'sound/foley/breaksound.ogg'
 	drop_sound = 'sound/foley/dropsound/gen_drop.ogg'
 	resistance_flags = FIRE_PROOF
-	armor = list("blunt" = 10, "slash" = 40, "stab" = 40, "bullet" = 8, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	prevent_crits = null
+	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)
 	flags_inv = HIDEFACE
 	body_parts_covered = FACE
 	block2add = FOV_BEHIND

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -179,8 +179,8 @@
 	drop_sound = 'sound/foley/dropsound/gen_drop.ogg'
 	resistance_flags = FIRE_PROOF
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)
-	flags_inv = HIDEFACE
-	body_parts_covered = FACE
+	flags_inv = HIDEFACE|HIDEFACIALHAIR
+	body_parts_covered = FACE|EYES|MOUTH|HEAD|HAIR
 	block2add = FOV_BEHIND
 	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HIP
 	experimental_onhip = TRUE

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -178,6 +178,7 @@
 	break_sound = 'sound/foley/breaksound.ogg'
 	drop_sound = 'sound/foley/dropsound/gen_drop.ogg'
 	resistance_flags = FIRE_PROOF
+	armor = list("blunt" = 45, "slash" = 100, "stab" = 80, "bullet" = 20, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
 	body_parts_covered = FACE|EYES|MOUTH|HEAD|HAIR

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -24,7 +24,7 @@
 	armor = list("blunt" = 90, "slash" = 100, "stab" = 80, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = PLATEHIT
-	max_integrity = 150
+	max_integrity = 450
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
 
@@ -37,7 +37,7 @@
 	armor = list("blunt" = 70, "slash" = 90, "stab" = 60, "bullet" = 50, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = PLATEHIT
-	max_integrity = 100
+	max_integrity = 200
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/iron
 

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -383,8 +383,8 @@
 /obj/item/rogueweapon/sickle/scythe
 	force = 15
 	force_wielded = 25
-	possible_item_intents = list(DAGGER_CUT)
-	gripped_intents = list(SPEAR_BASH,DAGGER_CUT)
+	possible_item_intents = list(/datum/intent/axe/cut)
+	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop/battle/scythe,SPEAR_BASH)
 	name = "scythe"
 	desc = "A curved blade used to sow harvest."
 	icon_state = "scythe"
@@ -401,6 +401,10 @@
 	drop_sound = 'sound/foley/dropsound/wooden_drop.ogg'
 	smeltresult = /obj/item/ingot/iron
 	improvised = TRUE
+
+/datum/intent/axe/chop/battle/scythe
+	reach = 2
+	swingdelay = 5
 
 /obj/item/rogueweapon/sickle/scythe/getonmobprop(tag)
 	. = ..()

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -400,6 +400,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	drop_sound = 'sound/foley/dropsound/wooden_drop.ogg'
 	smeltresult = /obj/item/ingot/iron
+	wdefense = 6
 	improvised = TRUE
 
 /datum/intent/axe/chop/battle/scythe

--- a/code/modules/jobs/job_types/roguetown/church/mortician.dm
+++ b/code/modules/jobs/job_types/roguetown/church/mortician.dm
@@ -9,55 +9,68 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_patrons = ALL_DIVINE_PATRONS //gets set to necra on the outfit anyways lol
-	tutorial = "As an acolyte of a death god, you have been given the honor and rites  of putting the dead to rest instead of healing the living. Yamais bestows much wisdom in her reminders of our balance in life. Will you toil for her?"
+	tutorial = "The purpose of a Gravesinger, working on behalf of both the local temple and of the Adventurers' Guild, is two-fold. As a priest of Yamais, it is to be the shepard of spirits to their preferred destination, whether it be burial and reincarnation, or reanimated in their own body, restored and cured of decomposition. As an expert on the affairs of the dead, it is to assist Adventurers in locating missing or slain comrades and providing the testimony of the dead to the Hedgeknights. Additionally, you have some medical training and the tools to use them, along with the expectation that you should rescue the dying if you can."
 
 	outfit = /datum/outfit/job/roguetown/undertaker
 	display_order = JDO_GRAVEMAN
 	give_bank_account = TRUE
-	min_pq = -5
+	min_pq = 5
 	max_pq = null
 
 /datum/outfit/job/roguetown/undertaker
-	allowed_patrons = list(/datum/patron/divine/necra,/datum/patron/divine/pestra)
+	allowed_patrons = list(/datum/patron/divine/necra)
 
-/datum/outfit/job/roguetown/undertaker/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/undertaker/pre_equip(mob/living/carbon/human/H)//Updated to have medium armor, because they'll be at odds with Necromancers and likely be targeted by antags.
 	..()
-	head = /obj/item/clothing/head/roguetown/necrahood
+	head = /obj/item/clothing/head/roguetown/roguehood/surghood
+	mask = /obj/item/clothing/mask/rogue/skullmask
 	neck = /obj/item/clothing/neck/roguetown/psicross/necra
-	cloak = /obj/item/clothing/cloak/raincloak/mortus
-	armor = /obj/item/clothing/suit/roguetown/shirt/robe/necra
-	shirt = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
-	pants = /obj/item/clothing/under/roguetown/trou/leather/mourning
-	shoes = /obj/item/clothing/shoes/roguetown/boots
-	belt = /obj/item/storage/belt/rogue/leather/rope
+	gloves = /obj/item/clothing/gloves/roguetown/plate
+	cloak = /obj/item/clothing/cloak/templar/necra
+	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/surgrobe
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/half
+	pants = /obj/item/clothing/under/roguetown/platelegs
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
+	belt = /obj/item/storage/belt/rogue/leather/blackleather
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver =1, /obj/item/toy/cards/deck/tarot =1, /obj/item/scrying =1,)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver =1, /obj/item/toy/cards/deck/tarot =1, /obj/item/scrying =1, /obj/item/storage/fancy/skit =1, /obj/item/reagent_containers/glass/alembic =1)
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
-	backr = /obj/item/rogueweapon/shovel
-	backl = /obj/item/rogueweapon/sickle/scythe
-	backl = /obj/item/storage/backpack/rogue/satchel
+	beltl = /obj/item/rogueweapon/shovel/small
+	backr = /obj/item/rogueweapon/sickle/scythe
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)//So that they can be extra menacing with their scythe.
 		H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 1, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/magic/holy, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/magic/arcane, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/magic/holy, 5, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/magic/arcane, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/alchemy, 3, TRUE)
 		if(H.age == AGE_OLD)
-			H.mind.adjust_skillrank_up_to(/datum/skill/magic/holy, 1, TRUE)
-		H.change_stat("strength", 1)
+			H.mind.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+		H.change_stat("strength", 2)
 		H.change_stat("constitution", 2)
-		H.change_stat("intelligence", -2)
-		H.change_stat("endurance", 1)
-		H.change_stat("speed", 1)
+		H.change_stat("endurance", 2)
+		H.change_stat("intelligence", 1)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/stable)//Spare the dying
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/purge)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cure_rot)
+		H.grant_language(/datum/language_holder/abyssal)
+		H.grant_language(/datum/language_holder/celestial)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_SIXTHSENSE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_SEESPIRITS, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	H.update_sight()
 	H.cmode_music = 'sound/music/combat_clergy.ogg'
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_spells(H)

--- a/code/modules/jobs/job_types/roguetown/church/mortician.dm
+++ b/code/modules/jobs/job_types/roguetown/church/mortician.dm
@@ -63,6 +63,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/stable)//Spare the dying
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/purge)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cure_rot)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/seance)
 		H.grant_language(/datum/language_holder/abyssal)
 		H.grant_language(/datum/language_holder/celestial)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -142,3 +142,6 @@
 
 /datum/language_holder/abyssal
 	languages = list(/datum/language/hellspeak)
+
+/datum/language_holder/celestial
+	languages = list(/datum/language/celestial)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -730,6 +730,8 @@
 /mob/living/carbon/update_sight()
 	if(!client)
 		return
+	if(HAS_TRAIT(src, TRAIT_SEESPIRITS))//DK Change
+		see_invisible = SEE_INVISIBLE_OBSERVER
 //	if(stat == DEAD)
 //		sight = (SEE_TURFS|SEE_MOBS|SEE_OBJS)
 //		see_in_dark = 8

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -62,7 +62,7 @@
 			else
 				add_buff_timer(person)
 	else
-		to_chat(user, span_warning("I need to be holding ashes in my hand to cast this.")
+		to_chat(user, span_warning("I need to be holding ashes in my hand to cast this."))
 
 /obj/effect/proc_holder/spell/targeted/seance/proc/add_buff_timer(mob/living/user)
 	ADD_TRAIT(user, TRAIT_SEESPIRITS, MAGIC_TRAIT)

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -61,6 +61,8 @@
 				user.visible_message("[user] scatters the [sacrifice]", "I scatter the [sacrifice]!")
 			else
 				add_buff_timer(person)
+	else
+		to_chat(user, span_warning("I need to be holding ashes in my hand to cast this.")
 
 /obj/effect/proc_holder/spell/targeted/seance/proc/add_buff_timer(mob/living/user)
 	ADD_TRAIT(user, TRAIT_SEESPIRITS, MAGIC_TRAIT)

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -30,6 +30,53 @@
 			return
 	to_chat(user, span_red("I failed to perform the rites."))
 
+/obj/effect/proc_holder/spell/targeted/seance
+	name = "Seance"
+	range = 5
+	overlay_state = "consecrateburial"
+	releasedrain = 30
+	charge_max = 30 SECONDS
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	max_targets = 0
+	cast_without_targets = TRUE
+	sound = 'sound/magic/churn.ogg'
+	associated_skill = /datum/skill/magic/holy
+	invocation = "With ashes do I annoint the eyes and ears of those around me and allow them to commune with the dead."
+	invocation_type = "shout" //can be none, whisper, emote and shout
+	miracle = TRUE
+	devotion_cost = 50
+
+/obj/effect/proc_holder/spell/targeted/seance/cast(list/targets, mob/user = usr)
+	. = ..()
+	var/requirement = FALSE
+	var/sacrifice
+	for(var/obj/item/I in user.held_items)
+		if(istype(I, /obj/item/ash))
+			requirement = TRUE
+			sacrifice = I
+			qdel(sacrifice)
+	if(requirement == TRUE)
+		for(var/mob/living/carbon/human/person in view(2))
+			if(person == user)
+				user.visible_message("[user] scatters the [sacrifice]", "I scatter the [sacrifice]!")
+			else
+				add_buff_timer(person)
+
+/obj/effect/proc_holder/spell/targeted/seance/proc/add_buff_timer(mob/living/user)
+	ADD_TRAIT(user, TRAIT_SEESPIRITS, MAGIC_TRAIT)
+	ADD_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
+	user.remove_language(/datum/language_holder/abyssal)
+	user.update_sight()
+	addtimer(CALLBACK(src, PROC_REF(remove_buff), user), wait = 5 MINUTES)
+	to_chat(user, span_notice("My eyes and ears become aware of the spectral."))
+
+/obj/effect/proc_holder/spell/targeted/seance/proc/remove_buff(mob/living/user)
+	REMOVE_TRAIT(user, TRAIT_SEESPIRITS, MAGIC_TRAIT)
+	REMOVE_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
+	user.remove_language(/datum/language_holder/abyssal)
+	user.update_sight()
+	to_chat(user, span_warning("My eyes and ears grow blind to the spectral."))
+
 /obj/effect/proc_holder/spell/targeted/churn
 	name = "Churn Undead"
 	range = 2
@@ -84,7 +131,7 @@
 	return TRUE
 
 /obj/effect/proc_holder/spell/targeted/soulspeak
-	name = "Speak with Dead"
+	name = "Summon Spirit"
 	range = 5
 	overlay_state = "speakwithdead"
 	releasedrain = 30
@@ -94,12 +141,30 @@
 	cast_without_targets = TRUE
 	sound = 'sound/magic/churn.ogg'
 	associated_skill = /datum/skill/magic/holy
-	invocation = "oriri mortuus spiritus."
+	invocation = "Oriri mortuus spiritus."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 	miracle = FALSE
 	devotion_cost = 0
+	var/summoned_spirit
 
 /obj/effect/proc_holder/spell/targeted/soulspeak/cast(list/targets,mob/user = usr)
+	if(summoned_spirit)
+		var/mob/living/carbon/spirit/SS = summoned_spirit
+		to_chat(user, "You dismiss the spirit to the underworld.")
+		to_chat(SS, "[user.real_name] returns you to the underworld. If you are wrongfully denied your reward by your summoner, please open a ticket.")
+		for(var/obj/effect/landmark/underworld/A in GLOB.landmarks_list)
+			for(var/obj/item/I in SS.held_items)
+				if(!istype(I, /obj/item/roguecoin/silver) || !istype(I, /obj/item/flashlight/lantern/shrunken))
+					. |= SS.dropItemToGround(I)
+				if(istype(I, /obj/item/roguecoin/silver))
+					to_chat(SS, "As you return across the veil to the underworld, the silver coin in your hand is transformed.")
+					var/obj/item/underworld/coin/C = new
+					SS.put_in_hand(C)
+			SS.loc = A.loc
+			SS.invisibility = initial(SS.invisibility)
+		user.remove_language(/datum/language_holder/abyssal)
+		summoned_spirit = null
+		return
 	var/mob/living/carbon/spirit/capturedsoul = null
 	var/list/souloptions = list()
 	var/list/itemstorestore = list()
@@ -110,12 +175,14 @@
 		return
 	for(var/mob/living/carbon/spirit/P in GLOB.carbon_list)
 		if(P.livingname == pickedsoul)
-			to_chat(P, "You feel yourself being pulled out of the underworld.")
+			to_chat(P, "You feel yourself being summoned to a Gravesinger.")
 			sleep(2 SECONDS)
 			P.loc = user.loc
+			user.say("I call upon the soul of [P.livingname] to become corporeal and walk this world for a time. In return for your obediance, I offer the choice of reincarnation by paying your toll in silver, or the choice of reanimation, by returning your body to life.", language = /datum/language/common, forced = "invocation")
 			capturedsoul = P
-			P.invisibility = INVISIBILITY_OBSERVER
-			user.grant_language(/datum/language_holder/abyssal)
+			summoned_spirit = capturedsoul
+			P.invisibility = 0
+/*
 			for(var/obj/item/I in P.held_items) // this is big ass, will revisit later
 				. |= P.dropItemToGround(I)
 				if(istype(I, /obj/item/underworld/coin))
@@ -123,22 +190,26 @@
 				if(istype(I, /obj/item/flashlight/lantern/shrunken))
 					itemstorestore |= "lamp"
 				qdel(I)
+*/
 			break
 		to_chat(P, "[itemstorestore]")
 	if(capturedsoul)
-		spawn(2 MINUTES)
-			to_chat(user, "The soul returns to the underworld.")
-			to_chat(capturedsoul, "You feel yourself being pulled back to the underworld.")
+		spawn(60 MINUTES)
+			to_chat(user, "The soul returns to the underworld as your spell expires.")
+			to_chat(capturedsoul, "You feel yourself being pulled to the underworld as your summoner's spell expires. The carriage awaits, if your summoner")
 			for(var/obj/effect/landmark/underworld/A in GLOB.landmarks_list)
 				capturedsoul.loc = A.loc
 				capturedsoul.invisibility = initial(capturedsoul.invisibility)
-				for(var/I in itemstorestore)
-					if(I == "token")
+				for(var/obj/item/I in capturedsoul.held_items)
+					if(istype(I, /obj/item/roguecoin/silver))
+						qdel(I)
+						to_chat(capturedsoul, "As you return across the veil to the underworld, the silver coin in your hand is transformed.")
 						var/obj/item/underworld/coin/C = new
 						capturedsoul.put_in_hands(C)
-					if(I == "lamp")
-						var/obj/item/flashlight/lantern/shrunken/L = new
-						capturedsoul.put_in_hands(L)
-			user.remove_language(/datum/language_holder/abyssal)
-		to_chat(user, "<font color='blue'>I feel a cold chill run down my spine, a presence has arrived.</font>")
-		capturedsoul.Paralyze(1200)
+					if(istype(I, /obj/item/flashlight/lantern/shrunken))
+						return
+					else
+						. |= capturedsoul.dropItemToGround(I)
+			summoned_spirit = null
+		to_chat(user, "<font color='blue'>I feel a cold chill run down my spine; the spirit has arrived.</font>")
+		capturedsoul.Immobilize(10 SECONDS)

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -65,7 +65,7 @@
 /obj/effect/proc_holder/spell/targeted/seance/proc/add_buff_timer(mob/living/user)
 	ADD_TRAIT(user, TRAIT_SEESPIRITS, MAGIC_TRAIT)
 	ADD_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
-	user.remove_language(/datum/language_holder/abyssal)
+	user.grant_language(/datum/language_holder/abyssal)
 	user.update_sight()
 	addtimer(CALLBACK(src, PROC_REF(remove_buff), user), wait = 5 MINUTES)
 	to_chat(user, span_notice("My eyes and ears become aware of the spectral."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Per my announcement on Discord, this is part 1 of a 2-part update to the Gravesinger, our flavor of Mortician. Here are the changes I've made:

- Merchant balloon/machine tax is now 20%
- Skull mask is now mostly equivalent in protection values to an iron mask (barring blunt, which it has only 45 to the iron mask's 90) and provides more coverage.
- The scythe has been adjusted to be a scarier weapon, gaining a chop attack with okay penetration and less hit delay than normal, having its cut intent upgraded from dagger version to axe version, and getting 6 base defense, like most polearms. Base force is unchanged.
- The max integrity of steel and iron bracers have increased for parity with other items of the same material
- Mortician can now wear medium armor and some duplicate equipment entries have been removed. They get a complement of steel plate limb armor, skull mask, and steel cuirass, worn over dark surgical robes for extra drip. Their satchel gains a surgical kit and alembic, and they have master skill in axes, so as to better utilize their scythes, and in miracles. If they pick OLD age, they  get legendary miracle skill and go from expert to legendary in Medicine. Due to their new duties and abilities surrounding summoning and/or following ghosts to corpses and the conflicts that are likely to arise from this, they have been given the +7 point stat spread that adventurers benefit from, in the form of +2 to STR, CON, END, and +1 to Intelligence.
- Morticians gain the new SEESPIRITS trait, as well as SIXTHSENSE, allowing them to see and hear ghosts. They also now speak Celestial and Infernal.
- Morticians receive the brand new Seance spell, allowing them to sacrifice a handful of ashes to grant everyone within 2 tiles the ability to see and hear ghosts and to understand and speak Infernal for 5 minutes. Mortician also receives the barber surgeon's Stabilize and Purge spells, as well as Cure Rot, because it's better to save the Undermaiden some paperwork and prevent the dying from dying if at all possible.
- Speak with Dead has been reworked into Summon Spirit, allowing the caster to pluck the soul of a person from the Underworld by selecting the name of their once-living body and making them corporeal for up to an hour, allowing them to be seen by others and to move around. The spell can be re-cast to dismiss the spirit early, as well. If the spirit is holding a silver coin when it is dismissed or the spell expires, the coin will transform into a soulcoin, allowing them to pay their toll immediately. Although, by the time the spell expires, the spirit will be eligible to use the carriage with or without the coin anyway.
- Last but not least, the Mortician has a minimum requirement of 5 PQ to play.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's long been a complaint that the Mortician role doesn't do anything that any other adventurer can't do themselves, and I aim to change that. Coming soon: A crematorium for Gravesingers to dispose of completely soul-less bodies and receive payment in the form of valuable remains and Lux to use in revival.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
