### PR TITLE
Nutshots no longer instantly kill vampires

### DIFF
--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -238,8 +238,6 @@
 			"The testicles are twisted!",
 			"The testicles are torsioned!",
 		)
-	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
-		affected.death()
 
 /datum/wound/cbt/on_life()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Removes critical weakness instakill check from torsion wound.

## Why It's Good For The Game

Torsion spell killing vamps instantly is very bad. Mundane nutshots killing vamps instantly is also pretty bad. It doesn't hurt THAT much, dude.
This also means nutshots don't oneshot goblins etc anymore, but aiming anything other than head against goblins is so rare I'm not sure I've ever seen it. And as funny as it is to hit someone in the nuts so hard they instantly die, it doesn't really make sense.