### PR TITLE
Adds secular diagnosis to the medical training quirk and healing warlocks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -412,6 +412,7 @@
 			eldritchhealing.targetnotification = "Maggots eat away my dead flesh!"
 			eldritchhealing.othernotification = "'s wounds are healed by... Maggots?"
 	H.mind.AddSpell(eldritchhealing)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular) // If you get healing, you get diagnose
 
 ///////////////////////////////
 //	Curse

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -176,6 +176,7 @@
 /datum/quirk/mtraining1/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	H.mind.special_items["Patch Kit"] = /obj/item/storage/fancy/ifak
 	H.mind.special_items["Surgery Kit"] = /obj/item/storage/fancy/skit
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Every other magical/miracle healer class already had it, making health pact/celestial warlocks an odd discrepancy.
Also adds the spell to the medical treatment quirk

The spell doesn't duplicate when taking classes/traits/pacts that'd give it multiple times during testing. Yell at me if it does when merged

I thought of adding it to the two apothecary towner classes, but since they're named the same, I didn't want to touch them until someone figures them out and separates them.