### PR TITLE
NPC goblin armor fix

### DIFF
--- a/code/modules/clothing/rogueclothes/npc/goblin.dm
+++ b/code/modules/clothing/rogueclothes/npc/goblin.dm
@@ -4,7 +4,7 @@
 	item_state = "plate_armor"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
 	smeltresult = /obj/item/ingot/iron
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = list(/datum/species/goblin, /datum/species/goblin/hell, /datum/species/goblin/cave, /datum/species/goblin/sea, /datum/species/goblin/moon)
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|VITALS
 	sellprice = 0
 
@@ -14,16 +14,26 @@
 	item_state = "leather_armor"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
 	body_parts_covered = CHEST|GROIN|ARMS|VITALS
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = list(/datum/species/goblin, /datum/species/goblin/hell, /datum/species/goblin/cave, /datum/species/goblin/sea, /datum/species/goblin/moon)
 	sellprice = 0
 
-/obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
+// /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
+//	name = "goblin loincloth"
+//	icon_state = "cloth_armor"
+//	item_state = "cloth_armor"
+//	icon = 'icons/roguetown/mob/monster/goblins.dmi'
+//	allowed_race = list(/datum/species/goblin)
+//	armor = null
+//	sellprice = 0
+
+/obj/item/clothing/under/roguetown/loincloth/goblinloin
 	name = "goblin loincloth"
+	desc = "smells funny."
+	icon = 'icons/roguetown/mob/monster/goblins.dmi'
+	mob_overlay_icon = 'icons/roguetown/mob/monster/goblins.dmi'
 	icon_state = "cloth_armor"
 	item_state = "cloth_armor"
-	icon = 'icons/roguetown/mob/monster/goblins.dmi'
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
-	armor = null
+	allowed_race = list(/datum/species/goblin, /datum/species/goblin/hell, /datum/species/goblin/cave, /datum/species/goblin/sea, /datum/species/goblin/moon)
 	sellprice = 0
 
 /obj/item/clothing/head/roguetown/helmet/leather/goblin
@@ -31,7 +41,7 @@
 	icon_state = "leather_helm_item"
 	item_state = "leather_helm"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = list(/datum/species/goblin, /datum/species/goblin/hell, /datum/species/goblin/cave, /datum/species/goblin/sea, /datum/species/goblin/moon)
 	sellprice = 0
 
 /obj/item/clothing/head/roguetown/helmet/goblin
@@ -39,7 +49,7 @@
 	icon_state = "plate_helm_item"
 	item_state = "plate_helm"
 	icon = 'icons/roguetown/mob/monster/goblins.dmi'
-	allowed_race = list(/mob/living/carbon/human/species/goblin)
+	allowed_race = list(/datum/species/goblin, /datum/species/goblin/hell, /datum/species/goblin/cave, /datum/species/goblin/sea, /datum/species/goblin/moon)
 	body_parts_covered = HEAD|EARS|HAIR|EYES
 	sellprice = 0
 	smeltresult = /obj/item/ingot/iron

--- a/code/modules/jobs/job_types/roguetown/goblin/tribalcook.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/tribalcook.dm
@@ -17,7 +17,6 @@
 
 /datum/outfit/job/roguetown/tribalcook/pre_equip(mob/living/carbon/human/H)
 	..()
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tribalrag
 	pants = /obj/item/clothing/under/roguetown/loincloth/brown
 	belt = /obj/item/storage/belt/rogue/leather/rope

--- a/code/modules/jobs/job_types/roguetown/goblin/tribalsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/tribalsmith.dm
@@ -16,7 +16,6 @@
 
 /datum/outfit/job/roguetown/tribalsmith/pre_equip(mob/living/carbon/human/H)
 	..()
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tribalrag
 	pants = /obj/item/clothing/under/roguetown/loincloth/brown
 	belt = /obj/item/storage/belt/rogue/leather

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -262,6 +262,10 @@
 		body_overlay = mutable_appearance(icon, "[wear_armor.item_state]", -ARMOR_LAYER)
 		if(body_overlay)
 			standing += body_overlay
+	if(wear_pants)
+		body_overlay = mutable_appearance(icon, "[wear_pants.item_state]", -ARMOR_LAYER)
+		if(body_overlay)
+			standing += body_overlay
 	if(head)
 		body_overlay = mutable_appearance(icon, "[head.item_state]", -ARMOR_LAYER)
 		if(body_overlay)
@@ -273,6 +277,8 @@
 
 /mob/living/carbon/human/species/goblin/update_inv_head()
 	update_wearable()
+/mob/living/carbon/human/species/goblin/update_inv_pants()
+  	update_wearable()
 /mob/living/carbon/human/species/goblin/update_inv_armor()
 	update_wearable()
 
@@ -319,6 +325,8 @@
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 //	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_GENERIC)
 //	blue breathes underwater, need a new specific one for this maybe organ cheque
 //	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_GENERIC)
@@ -390,13 +398,13 @@
 	switch(loadout)
 		if(1) //tribal spear
 			r_hand = /obj/item/rogueweapon/spear/stone
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
+			pants = /obj/item/clothing/under/roguetown/loincloth/goblinloin
 		if(2) //tribal axe
 			r_hand = /obj/item/rogueweapon/stoneaxe
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
+			pants = /obj/item/clothing/under/roguetown/loincloth/goblinloin
 		if(3) //tribal club
 			r_hand = /obj/item/rogueweapon/mace/woodclub
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
+			pants = /obj/item/clothing/under/roguetown/loincloth/goblinloin
 			if(prob(10))
 				head = /obj/item/clothing/head/roguetown/helmet/leather/goblin
 		if(4) //lightly armored sword/flail/daggers
@@ -410,6 +418,7 @@
 				r_hand = /obj/item/rogueweapon/huntingknife/stoneknife
 				l_hand = /obj/item/rogueweapon/huntingknife/stoneknife
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/goblin
+			pants = /obj/item/clothing/under/roguetown/loincloth/goblinloin
 			if(prob(80))
 				head = /obj/item/clothing/head/roguetown/helmet/leather/goblin
 		if(5) //heavy armored sword/flail/shields
@@ -428,10 +437,11 @@
 			if(prob(20))
 				r_hand = /obj/item/rogueweapon/flail
 			l_hand = /obj/item/rogueweapon/shield/wood
+			pants = /obj/item/clothing/under/roguetown/loincloth/goblinloin
 		if(6) //tribal club with rope for lewd
 			r_hand = /obj/item/rogueweapon/mace/woodclub
 			l_hand = /obj/item/rope
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin
+			//pants = /obj/item/clothing/under/roguetown/loincloth/goblinloin //lewd goblins don't need lioncloths i guess
 			H.seeksfuck = TRUE
 
 


### PR DESCRIPTION
## About The Pull Request

Fix the npc goblin armor, now all the npc goblin types can spawn with some pretection (or at least some loincloth to hide their bits).

![Captura de tela 2024-11-29 142948](https://github.com/user-attachments/assets/217867f1-bb73-46b8-b62a-e8587fb9289d)
![Captura de tela 2024-11-29 163515](https://github.com/user-attachments/assets/3301a17c-57a9-4f2a-9bbd-96ad6050e569)
![Captura de tela 2024-11-29 155104](https://github.com/user-attachments/assets/fafd62ac-8b76-4682-99e2-6b85b5d30327)
![Captura de tela 2024-11-29 163829](https://github.com/user-attachments/assets/354ab23d-2f28-4ed6-939b-b32710a1a02a)


## Why It's Good For The Game

it could make fighting goblins a bit more challenging now that they have some protection.
