### PR TITLE
Fix emotes not resetting message

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -19,6 +19,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak())
 			message = "makes a noise. Tears stream down their face."
+		else
+			message = initial(message)
 
 
 /datum/emote/living/carbon/human/sexmoanlight
@@ -33,6 +35,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak())
 			message = "makes a noise."
+		else
+			message = initial(message)
 
 /datum/emote/living/carbon/human/sexmoanhvy
 	key = "sexmoanhvy"
@@ -46,6 +50,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak())
 			message = "makes a noise."
+		else
+			message = initial(message)
 
 /datum/emote/living/carbon/human/eyebrow
 	key = "eyebrow"
@@ -88,6 +94,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak())
 			message = "makes a muffled grumbling noise."
+		else
+			message = initial(message)
 
 /datum/emote/living/carbon/human/handshake
 	key = "handshake"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -947,6 +947,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled noise."
+		else
+			message = initial(message)
 
 
 /datum/emote/living/clap
@@ -1222,6 +1224,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled yawn."
+		else
+			message = initial(message)
 
 /datum/emote/living/warcry
 	key = "warcry"
@@ -1241,6 +1245,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled shout!"
+		else
+			message = initial(message)
 
 /datum/emote/living/custom
 	key = "me"
@@ -1407,6 +1413,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled yip."
+		else
+			message = initial(message)
 
 /datum/emote/living/yap
 	key = "yap"
@@ -1426,6 +1434,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled yap."
+		else
+			message = initial(message)
 
 
 /datum/emote/living/coyhowl
@@ -1446,6 +1456,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled howl."
+		else
+			message = initial(message)
 
 
 /datum/emote/living/snap
@@ -1492,6 +1504,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled bark."
+		else
+			message = initial(message)
 
 /datum/emote/living/whine
 	key = "whine"
@@ -1511,6 +1525,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled whine."
+		else
+			message = initial(message)
 /datum/emote/living/cackle
 	key = "cackle"
 	key_third_person = "cackles"
@@ -1529,6 +1545,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled cackle."
+		else
+			message = initial(message)
 
 /datum/emote/living/blink
 	key = "blink"
@@ -1561,6 +1579,8 @@
 		var/mob/living/carbon/C = user
 		if(C.silent || !C.can_speak_vocal())
 			message = "makes a muffled meow."
+		else
+			message = initial(message)
 
 /datum/emote/living/hiss
 	key = "hiss"

--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -9,6 +9,7 @@
 	. = ..() && intentional
 
 /datum/emote/living/subtle/run_emote(mob/user, params, type_override = null, intentional = FALSE)
+	var/message_to_send = params
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
 	else if(QDELETED(user))
@@ -19,22 +20,21 @@
 	else if(!params)
 		var/custom_emote = copytext(sanitize(input("What does your character subtly do?") as text|null), 1, MAX_MESSAGE_LEN)
 		if(custom_emote)
-			message = custom_emote
+			message_to_send = custom_emote
 			emote_type = EMOTE_VISIBLE
 	else
-		message = params
 		if(type_override)
 			emote_type = type_override
 
-	user.log_message("SUBTLE - " + message, LOG_EMOTE)
-	message = "<b>[user]</b> " + message
+	user.log_message("SUBTLE - " + message_to_send, LOG_EMOTE)
+	message_to_send = "<b>[user]</b> " + message_to_send
 
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!M.client || isnewplayer(M))
 			continue
 		var/T = get_turf(user)
 		if(M.stat == DEAD && M.client && (M.client.prefs?.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
-			M.show_message(message)
+			M.show_message(message_to_send)
 
-	user.visible_message("<i>[message]</i>", vision_distance = 1)
+	user.visible_message("<i>[message_to_send]</i>", vision_distance = 1)
 


### PR DESCRIPTION
Fixes a code quality issue with emotes not resetting `message` after being changed.

This should be merged ASAP.