### PR TITLE
Adds Magician Apprentice Spells to Magician

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -9,7 +9,19 @@
 
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_sexes = list(MALE, FEMALE)
-	spells = list(/obj/effect/proc_holder/spell/invoked/projectile/fireball/greater, /obj/effect/proc_holder/spell/invoked/arcyne_storm, /obj/effect/proc_holder/spell/invoked/invisibility, /obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe, /obj/effect/proc_holder/spell/targeted/ethereal_jaunt, /obj/effect/proc_holder/spell/aoe_turf/rogue_knock)
+	spells = list (
+		/obj/effect/proc_holder/spell/invoked/projectile/fireball/greater,
+		/obj/effect/proc_holder/spell/invoked/projectile/spitfire,
+		/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt,
+		/obj/effect/proc_holder/spell/invoked/arcyne_storm,
+		/obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe,
+		/obj/effect/proc_holder/spell/aoe_turf/conjure/Wolf,
+		/obj/effect/proc_holder/spell/invoked/invisibility,
+		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
+		/obj/effect/proc_holder/spell/targeted/touch/prestidigitation,
+		/obj/effect/proc_holder/spell/targeted/forcewall,
+		/obj/effect/proc_holder/spell/targeted/ethereal_jaunt,
+		/obj/effect/proc_holder/spell/aoe_turf/rogue_knock)
 	display_order = JDO_MAGICIAN
 	tutorial = "Your creed is one dedicated to the conquering of the arcane arts and the constant thrill of knowledge. \
 		You are one of the Arch-Magicians of Dreamkeeps Magick Academy; Ravenloft. You help teach and manage the students of this Academy.\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds the starting spells for Magician Apprentice to Magician.

## Why It's Good For The Game

- I think it just makes sense that the Magician would know the spells they allegedly taught to their Apprentices. It also is extremely hard to roleplay teaching someone about a spell that they possess as an Apprentice, but that the Magician doesn't possess unless they go dungeon-crawling to find the scroll since Prospero isn't able to produce some of the starting Apprentice spells.

- I don't think it'll have any impact on balance since they're pretty low level spells and also the PQ for Magician is 8 so if people are shitters they can just be blasted.

- I tested it and there were no bugs/HUD issues that popped up that I saw.