### PR TITLE
Less annoying evil healing sound

### DIFF
--- a/code/modules/spells/roguetown/acolyte/zizo.dm
+++ b/code/modules/spells/roguetown/acolyte/zizo.dm
@@ -7,7 +7,7 @@
 	range = 4
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-	sound = 'sound/vo/mobs/ghost/whisper (1).ogg'
+	sound = 'sound/magic/antimagic.ogg'
 	invocation_type = "none"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE


### PR DESCRIPTION
## About The Pull Request

Changes uncommon deity heal sound to antimagic.ogg instead of whisper (1).ogg.

## Why It's Good For The Game

The current clip is so long that it lasts exactly as long as the spell cooldown does. So if healing off cooldown everyone has to listen to this constant ghost whispering. Very annoying. Replacement antimagic.ogg is about as long as heal.ogg and still significantly more sinister. Should not cause confusion - the sound is currently only used for very rare Ring of Null Magic (I have not seen someone use this once) and for Lich revival, which prompts a big red warning message in chat.