### PR TITLE
Warlock pact weapons are much harder to lose

### DIFF
--- a/code/datums/components/pact_weapon.dm
+++ b/code/datums/components/pact_weapon.dm
@@ -27,7 +27,7 @@
 		weapon.wdefense *= 1.2
 		weapon.max_blade_int *= 1.2
 		weapon.blade_int = weapon.max_blade_int
-		weapon.max_integrity *= 1.2
+		weapon.max_integrity *= 2
 		weapon.obj_integrity = weapon.max_integrity
 		weapon.minstr = 1
 		ADD_TRAIT(weapon, TRAIT_NOEMBED, TRAIT_GENERIC)
@@ -62,10 +62,10 @@
 /datum/component/pact_weapon/proc/equipped(obj/item/source, mob/user, slot)
 	var/mob/living/target = user
 	if(target != weapon_owner) //you dont own the weapon
-		to_chat(weapon_owner, span_warning("[target] has equipped [weapon]!")) //message the rightful owner 
-		to_chat(target, span_warning("[weapon] burns you as you equip it!")) //message the wielder
-		target.apply_status_effect(/datum/status_effect/buff/pact_weapon_debuff) //apply debuff to wielder
-
+		to_chat(weapon_owner, span_warning("[target] tried to equip [weapon]!")) //message the rightful owner 
+		to_chat(target, span_danger("[weapon] slips from your grasp!")) //message the wielder
+		target.stun(10) //this is not yours, drop it
+/*
 /datum/component/pact_weapon/proc/dropped(obj/item/source, mob/user)
 	var/mob/living/target = user
 	if(target != weapon_owner) //you dont own the weapon
@@ -88,3 +88,4 @@
 	name = "Cursed Item"
 	desc = "An item I have equipped burns me periodically."
 	icon_state = "debuff"
+*/

--- a/code/datums/components/pact_weapon.dm
+++ b/code/datums/components/pact_weapon.dm
@@ -64,7 +64,7 @@
 	if(target != weapon_owner) //you dont own the weapon
 		to_chat(weapon_owner, span_warning("[target] tried to equip [weapon]!")) //message the rightful owner 
 		to_chat(target, span_danger("[weapon] slips from your grasp!")) //message the wielder
-		target.Stun(10) //this is not yours, drop it
+		target.dropItemToGround(source) //this is not yours, drop it
 /*
 /datum/component/pact_weapon/proc/dropped(obj/item/source, mob/user)
 	var/mob/living/target = user

--- a/code/datums/components/pact_weapon.dm
+++ b/code/datums/components/pact_weapon.dm
@@ -39,7 +39,7 @@
 	if(istype(parent, /obj/item/rogueweapon))
 		RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND_RIGHT, PROC_REF(attack_right))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(equipped))
-		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(dropped))
+		// RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(dropped))
 
 /datum/component/pact_weapon/proc/attack_right(obj/item/source, mob/user)
 	var/mob/living/target = user
@@ -64,7 +64,7 @@
 	if(target != weapon_owner) //you dont own the weapon
 		to_chat(weapon_owner, span_warning("[target] tried to equip [weapon]!")) //message the rightful owner 
 		to_chat(target, span_danger("[weapon] slips from your grasp!")) //message the wielder
-		target.stun(10) //this is not yours, drop it
+		target.Stun(10) //this is not yours, drop it
 /*
 /datum/component/pact_weapon/proc/dropped(obj/item/source, mob/user)
 	var/mob/living/target = user


### PR DESCRIPTION
## About The Pull Request

Pact weapons now have 2x standard durability, up from 1.2x.
Pact weapons now force people who aren't the owner to drop them, instead of applying a burn debuff.

## Why It's Good For The Game

Losing your main class feature permanently is ass.

The burn debuff was so weak it was hard to even notice it existed. As for the new effect: compare to Hedge stun maces that electrocute you for over 10 seconds. This is a 1-second stun mostly to make you drop the item.

If you think this is overpowered somehow, D&D Warlock pact weapon is entirely made of magic, vanishes when out of the warlock's possession, and can be resummoned infinitely. Procs are just too much of a headache at my level of BYOND knowledge for me to implement that. Also, Warlocks will not be able to read scrolls after #149 which gives a hard limit on their magic potential, meaning they will have to lean into their pact more - which means their pact weapon in this case.

Sub-rant: I don't know where people are pulling the "Warlock is actually OP" thing from. A class with no armor training or dodge training, identical or worse weapon training relative to other martial casters, flatly worse stats than other martial casters. Paladin in full plate armor with 11 total stat points can go invisible and chop you with expert-tier swords, Bladesingers get more spell points, can phase through walls, go invisible, also expert-tier swords... but _Warlocks_ are an issue. I would like to see someone articulate why.