### PR TITLE
Jayx Paladins get Misty Step and magic tab

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -150,3 +150,8 @@
 	//Max devotion limit - Paladins are stronger but cannot pray to gain all abilities beyond t2
 	C.grant_spells_templar(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	if(/datum/patron/inhumen/graggar)
+				if(H.mind)
+					H.mind.adjust_spellpoints(1)
+					H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)
+					cc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Jayx Paladins don't get jack despite being a follower of a MAGIC PHOENIX. This fixes that.

## Why It's Good For The Game

They don't even have a t2 coded in or anything. Jeez.
