### PR TITLE
Revert "Jayx Paladins get Misty Step and magic tab" [EMERGENT BUG FIX]

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -150,8 +150,3 @@
 	//Max devotion limit - Paladins are stronger but cannot pray to gain all abilities beyond t2
 	C.grant_spells_templar(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
-	if(/datum/patron/inhumen/graggar)
-				if(H.mind)
-					H.mind.adjust_spellpoints(1)
-					H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)
-					cc


### PR DESCRIPTION
Reverts StoneHedgeSS13/StoneHedge#156

It causes a fatal compile error which likely prevents the server from compiling. This is an emergent fix, I'll correct the original PR in a separate PR.