### PR TITLE
Temporarily disables all invisibility spells

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -26,7 +26,7 @@
 	worshippers = "Wizards, Scholars, Wisened Folk,"
 	mob_traits = list(TRAIT_NOCSNEAK, TRAIT_NIGHT_OWL)
 	t1 = /obj/effect/proc_holder/spell/invoked/blindness
-	t2 = /obj/effect/proc_holder/spell/invoked/invisibility
+	//t2 = /obj/effect/proc_holder/spell/invoked/invisibility readd when invisibility spells are fixed
 	confess_lines = list(
 		"LUNE IS WISDOM!",
 		"LUNE'S PALE GLOWING EYES SEE ALL!",
@@ -96,7 +96,7 @@
 	worshippers = "Bards, Gamblers, Poets, Musicians, Diplomats and Artists."
 	mob_traits = list(TRAIT_BOG_TREKKING)
 	t1 = /obj/effect/proc_holder/spell/invoked/blindness
-	t2 = /obj/effect/proc_holder/spell/invoked/invisibility
+	//t2 = /obj/effect/proc_holder/spell/invoked/invisibility readd when invisibility spells are fixed
 	confess_lines = list(
 		"Elysius, cut us a path!",
 		"Lune guide me gentle!",

--- a/code/game/objects/structures/roguetown/loot.dm
+++ b/code/game/objects/structures/roguetown/loot.dm
@@ -47,7 +47,7 @@
 		/obj/item/book/granter/spell/blackstone/sicknessray = 5,
 		/obj/item/book/granter/spell/blackstone/strengthen_undead = 3,
 		/obj/item/book/granter/spell/blackstone/skeleton = 3,
-		/obj/item/book/granter/spell/blackstone/invisibility = 3,
+		///obj/item/book/granter/spell/blackstone/invisibility = 3, readd when invisibility spells are fixed
 		/obj/item/book/granter/spell/blackstone/greaterfireball = 2)))
 	return ..()
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -94,7 +94,7 @@
 			H.change_stat("endurance", 2)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/magicstone5e)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/encodethoughts5e)
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/invisibility)
+			//H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/invisibility) readd when fixed
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/featherfall)
 
 		if("Spellblade")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/bladesinger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/bladesinger.dm
@@ -53,5 +53,5 @@
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/boomingblade5e)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/greenflameblade5e)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish)
+	//H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish) readd when invisibility spells are fixed
 	H.verbs += list(/mob/living/carbon/human/proc/magicreport, /mob/living/carbon/human/proc/magiclearn)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -45,7 +45,7 @@
 
 //Rogue, crafty and tricky.
 /datum/outfit/job/roguetown/adventurer/rogue/proc/roguearch(mob/living/carbon/human/H)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish)
+	//H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish) readd when invisibility spells are fixed
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
@@ -95,7 +95,7 @@
 
 //Assassin, nearly same as rogue but not versatile in weapon skills yet specialized in knives.
 /datum/outfit/job/roguetown/adventurer/rogue/proc/assassinarch(mob/living/carbon/human/H)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish)
+	//H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish) readd when invisibility spells are fixed
 	shoes = /obj/item/clothing/shoes/roguetown/boots/hidden/berrypoison
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -33,7 +33,7 @@
 	head = /obj/item/clothing/head/roguetown/jester
 	neck = /obj/item/clothing/neck/roguetown/coif
 	mask = /obj/item/clothing/mask/rogue/facemask/gold
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish, /obj/item/book/granter/spell/blackstone/invisibility)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish)
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -16,7 +16,7 @@
 		/obj/effect/proc_holder/spell/invoked/arcyne_storm,
 		/obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe,
 		/obj/effect/proc_holder/spell/aoe_turf/conjure/Wolf,
-		/obj/effect/proc_holder/spell/invoked/invisibility,
+		///obj/effect/proc_holder/spell/invoked/invisibility, readd when fixed
 		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
 		/obj/effect/proc_holder/spell/targeted/touch/prestidigitation,
 		/obj/effect/proc_holder/spell/targeted/forcewall,

--- a/modular_stonehedge/code/game/objects/items/class_selectors.dm
+++ b/modular_stonehedge/code/game/objects/items/class_selectors.dm
@@ -65,7 +65,7 @@
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 			dressup(H, inventory_items)
 		if("Rogue")
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish)
+			//H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rogue_vanish) readd when invisibility spells are fixed
 			inventory_items = list(
 				/obj/item/clothing/neck/roguetown/bervor,
 				/obj/item/clothing/shoes/roguetown/boots/armor,

--- a/modular_stonehedge/code/game/objects/structures/dungeon/loot_generators/dungeon_chest.dm
+++ b/modular_stonehedge/code/game/objects/structures/dungeon/loot_generators/dungeon_chest.dm
@@ -314,7 +314,7 @@
 				/obj/item/book/granter/spell/blackstone/lightning = 3,
 				/obj/item/book/granter/spell/blackstone/fetch = 4,
 				/obj/item/book/granter/spell/blackstone/blindness = 1,
-				/obj/item/book/granter/spell/blackstone/invisibility = 3,
+				///obj/item/book/granter/spell/blackstone/invisibility = 3, readd when invisibility spells are fixed
 				/obj/item/book/granter/spell/blackstone/sicknessray = 2,
 				/obj/item/book/granter/spell/blackstone/strengthen_undead = 2
 			)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Disables invisibility spells of every source and for every class that had them. Except Jester, but he loses his scroll and only has it as a roundstart spell so he can't give it to someone else.

## Why It's Good For The Game
Invisibility spells are currently broken. They use a different system of stealth than sneaking and current detection methods simply break when trying to apply to these spells. This allows players to use an invisibility spell, freely hit a mob, get the stealth cooldown debuff that should unstealth them, but continue to freely hit the mob because this doesn't work. This exploit has become widespread to the point most people don't even know it's a bug.

When someone can find a fix for this they can re-add these spells to the relevant patrons and classes. Stealth spells need to end when:
- A player searches and detects you. (You get a message when this occurs, but the stealth remains)
- You hit a mob and it detects you. (Same as above)
- You backstab someone and get the stealth cooldown debuff. (Also broken)