### PR TITLE
Fixes dispelling of invisibility when discovered

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1390,7 +1390,7 @@
 		return FALSE
 	if(user != null && src == user)
 		return FALSE
-	if(invisibility || alpha == 0)//cloaked
+	if(bility || alpha == 0)//cloaked
 		return FALSE
 	// Now, are they viewable by a camera? (This is last because it's the most intensive check)
 	if(!near_camera(src))
@@ -1918,7 +1918,7 @@
 					if(prob(probby)) // first success will ping their location, but you need to succeed twice in a row to fully dispel magical invisibility with just your eyes - this should not be an easy thing to do
 						emote("huh")
 						to_chat(M, span_danger("[src]'s supernatural perception dispels my invisbility!"))
-						animate(user, alpha = 255, time = 1 SECONDS, easing = EASE_IN) // this will not remove the chat message when the invis spell actually wears off, slop code, but better than godmode invis
+						animate(M, alpha = 255, time = 1 SECONDS, easing = EASE_IN) // this will not remove the chat message when the invis spell actually wears off, slop code, but better than godmode invis
 			else
 				if(M.m_intent == MOVE_INTENT_SNEAK)
 					if(M.client?.prefs.showrolls)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1390,7 +1390,7 @@
 		return FALSE
 	if(user != null && src == user)
 		return FALSE
-	if(bility || alpha == 0)//cloaked
+	if(invisibility || alpha == 0)//cloaked
 		return FALSE
 	// Now, are they viewable by a camera? (This is last because it's the most intensive check)
 	if(!near_camera(src))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1902,8 +1902,8 @@
 				continue
 			//if(see_invisible < M.invisibility)
 				//continue
-			if(M.mob_timers[MT_INVISIBILITY] > world.time) // Check if the mob is affected by the invisibility spell
-				continue
+			// if(M.mob_timers[MT_INVISIBILITY] > world.time) Check if the mob is affected by the invisibility spell - commented out, this makes invis immune to active spotting, cringe
+				// continue
 			var/probby = 3 * STAPER
 			if(M.mind)
 				probby -= (M.mind.get_skill_level(/datum/skill/misc/sneaking) * 10)
@@ -1914,6 +1914,11 @@
 					emote("huh")
 					to_chat(M, span_danger("[src] sees me! I'm found!"))
 					M.apply_status_effect(/datum/status_effect/debuff/stealthcd)
+				if(M.mob_timers[MT_INVISIBILITY] > world.time)
+					if(prob(probby)) // first success will ping their location, but you need to succeed twice in a row to fully dispel magical invisibility with just your eyes - this should not be an easy thing to do
+						emote("huh")
+						to_chat(M, span_danger("[src]'s supernatural perception dispels my invisbility!"))
+						animate(user, alpha = 255, time = 1 SECONDS, easing = EASE_IN) // this will not remove the chat message when the invis spell actually wears off, slop code, but better than godmode invis
 			else
 				if(M.m_intent == MOVE_INTENT_SNEAK)
 					if(M.client?.prefs.showrolls)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -193,6 +193,7 @@
 			dam += 30
 			dam *= sneakmult
 			user.apply_status_effect(/datum/status_effect/debuff/stealthcd)
+			animate(user, alpha = 255, time = 1 SECONDS, easing = EASE_IN) // shitcode to prevent infinite attacks from invisibility
 			to_chat(src, span_userdanger("SNEAK ATTACK!!! CRITICAL HIT CHANCE INCREASED!"))
 			to_chat(user, span_userdanger("SNEAK ATTACK!!! CRITICAL HIT CHANCE INCREASED!"))
 			user.mind?.adjust_experience(/datum/skill/misc/sneaking, user.STAINT * 5, TRUE)
@@ -254,6 +255,7 @@
 			var/sneakmult = 2 + (user.mind.get_skill_level(/datum/skill/misc/sneaking))
 			dam += 30
 			dam *= sneakmult
+			animate(user, alpha = 255, time = 1 SECONDS, easing = EASE_IN) // shitcode to prevent infinite attacks from invisibility
 			user.apply_status_effect(/datum/status_effect/debuff/stealthcd)
 			to_chat(src, span_userdanger("SNEAK ATTACK!!! CRITICAL HIT CHANCE INCREASED!"))
 			to_chat(user, span_userdanger("SNEAK ATTACK!!! CRITICAL HIT CHANCE INCREASED!"))
@@ -318,11 +320,12 @@
 			dam += 10
 	if(owner.resting)
 		dam += 30
-	if(from_behind || user?.alpha <= 15)//Dreamkeep change -- Attacks from stealth should have greatly increased crit rate.
+	if(from_behind || user.alpha <= 15)//Dreamkeep change -- Attacks from stealth should have greatly increased crit rate.
 		if(user.mind && !HAS_TRAIT(owner, TRAIT_BLINDFIGHTING) && !user.has_status_effect(/datum/status_effect/debuff/stealthcd))
 			var/sneakmult = 2 + (user.mind.get_skill_level(/datum/skill/misc/sneaking))
 			dam += 30
 			dam *= sneakmult
+			animate(user, alpha = 255, time = 1 SECONDS, easing = EASE_IN) // shitcode to prevent infinite attacks from invisibility
 			user.apply_status_effect(/datum/status_effect/debuff/stealthcd)
 			to_chat(src, span_userdanger("SNEAK ATTACK!!! CRITICAL HIT CHANCE INCREASED!"))
 			to_chat(user, span_userdanger("SNEAK ATTACK!!! CRITICAL HIT CHANCE INCREASED!"))
@@ -408,7 +411,7 @@
 						attempted_wounds +=/datum/wound/fracture/head/nose
 					else
 						attempted_wounds += /datum/wound/facial/disfigurement/nose
-				else if(!(zone_precise in knockout_zones))
+				else if(!zone_precise in knockout_zones)
 					attempted_wounds += /datum/wound/fracture/head/brain
 
 	for(var/wound_type in shuffle(attempted_wounds))
@@ -564,3 +567,4 @@
 	if(skeletonized)
 		returned_flags |= SURGERY_INCISED | SURGERY_RETRACTED | SURGERY_DRILLED //ehh... we have access to whatever organ is there
 	return returned_flags
+

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -411,7 +411,7 @@
 						attempted_wounds +=/datum/wound/fracture/head/nose
 					else
 						attempted_wounds += /datum/wound/facial/disfigurement/nose
-				else if(!zone_precise in knockout_zones)
+				else if(!(zone_precise in knockout_zones))
 					attempted_wounds += /datum/wound/fracture/head/brain
 
 	for(var/wound_type in shuffle(attempted_wounds))


### PR DESCRIPTION
## About The Pull Request

- Sneak attacks forcibly set mob transparency to 0%. This ends most gameplay effects of invisibility.
- Succeeding a search check with disadvantage will dispel invisibility effects early. If the first roll succeeds you will still get a ping of their location.

## Why It's Good For The Game

Fixing things instead of removing them from the code is generally for the best.

Sneak attack check will not reveal you when hitting non-sneak attacks from stealth. This only occurs (or SHOULD only occur, outside of slop that I didn't notice) when the other person has the blindfighting trait.

Seeing someone who is magically invisible should be more difficult than seeing someone who is just sneaking. The ping is still a significant warning.

## Issues:

Blindfighting, as mentioned. I could put a reveal check every single time someone clicks but that would drive me insane from how shit that code is, and probably also break actual stealth uses of invisibility. Like picking locks, smashing a window and hopping through...

Grabs probably also will not end invisibility for the same reason. I think it's for the best to keep this one, invisibility could be used to drag a friend out of a packed dungeon without mobs noticing you. Actual utility instead of only for mob bonking.

Ranged attacks still do not reveal the attacker, both for magical and mundane stealth. This is thematically appropriate, I think. Crossbow bolt from the shadows, nobody can tell where it came from, that sort of thing.

This will not end the invisibility status effect, but a lot of logic is actually based on the alpha of the sprite. Mobs _will_ "wake up" and start attacking you again, which is the main concern Space seems to have. There may be broken aspects in PVE I'm missing in testing, but I'm 100% certain this ends any PVP effects of invisibility.

Text saying you became visible still occurs. This already happens if someone tries to cast invisibility on an already-invisible target: the first timer ends both invisibility but the second message still plays. Probably annoying to fix.

Any effect that's meant to permanently make the player transparent will break whenever they land a sneak attack. I'm not sure why someone would add that, but if you want to, like - make someone look ghostly for an event, or maybe some invisibility cloak (should break stealth anyway) or The One Ring or something, then you'll need to keep this in mind.