### PR TITLE
Makes scythes polearms (and craftable)

### DIFF
--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -393,7 +393,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	sharpness = IS_SHARP
-	associated_skill = /datum/skill/combat/axes
+	associated_skill = /datum/skill/combat/polearms
 	//dropshrink = 0.8
 	wlength = 33
 	var/list/forked = list()

--- a/code/modules/jobs/job_types/roguetown/church/mortician.dm
+++ b/code/modules/jobs/job_types/roguetown/church/mortician.dm
@@ -42,7 +42,7 @@
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)//So that they can be extra menacing with their scythe.
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)//So that they can be extra menacing with their scythe.
 		H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 2, TRUE)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -271,6 +271,14 @@
 	craftdiff = 3
 	i_type = "Weapons"
 
+/datum/anvil_recipe/weapons/scythe
+	name = "Scythe (+1 Steel) (+1 Small Log)"
+	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
+	created_item = /obj/item/rogueweapon/sickle/scythe
+	craftdiff = 3
+	i_type = "Weapons"
+
 /datum/anvil_recipe/weapons/lucerne
 	name = "Lucerne (+ iron) (+1 Small Log)"
 	req_bar = /obj/item/ingot/iron


### PR DESCRIPTION
## About The Pull Request

- Scythes now use polearms skill instead of axes.
- Scythes can be smithed with an identical cost to halberds.
- Gravesingers have polearms skill instead of axes, in line with their main weapon now using a different skill.

## Why It's Good For The Game

A blade on a six-foot-long stick is not an axe. It's essentially a bardiche, which is a polearm. Someone who can use a scythe effectively in combat is going to adapt to a halberd or spear much more easily than they will to an axe. It also has reach attacks. And polearm-tier defense modifiers. The only thing convincingly "axe" about it in gameplay is, literally, the skill it uses.

As for crafting: scythes are a common farming tool, not an artifact that is only carried by highly-skilled holy warriors and ancient horrors. It would also potentially be a slightly weaker (25 instead of the usual 30 force) option for anyone with polearm skill who wants something you can actually store in a back slot. Ideally someone will eventually sprite an actual bardiche that I can make the steel variant of an iron scythe, but for now the scythe is steel.

Unfortunately this does shrink the "viable combat axes" pool back down to literally just the battleaxe, but we do have a two-handed greataxe (like the scythe, mostly exclusive to enemy mobs) lying around that someone could easily use for that. Apparently it currently uses sword skill, and I don't think it's craftable either. Someone else can decide the balance of all that.