### PR TITLE
Gravesingers trained in their own pants

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/mortician.dm
+++ b/code/modules/jobs/job_types/roguetown/church/mortician.dm
@@ -70,7 +70,7 @@
 	ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SIXTHSENSE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SEESPIRITS, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	H.update_sight()
 	H.cmode_music = 'sound/music/combat_clergy.ogg'
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)


### PR DESCRIPTION
## About The Pull Request

Gravesingers now have heavy armor training.

## Why It's Good For The Game

Someone gave pants actual armor classes. Gravesingers start with heavy plated chausses, but only have medium armor training.

Other possible solutions: steel chain legs for gravesingers (which doesn't match the rest of their armor) or lowering plated chausses AC (but it's probably for the best that you need heavy training). Up to maintainers.