### PR TITLE
Armor class revert

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -609,7 +609,6 @@
 	icon_state = "sallet_visor"
 	max_integrity = 275
 	adjustable = CAN_CADJUST
-	armor_class = ARMOR_CLASS_MEDIUM
 	block2add = FOV_BEHIND
 	max_integrity = 400
 
@@ -644,7 +643,6 @@
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES|MOUTH
-	armor_class = ARMOR_CLASS_MEDIUM
 	block2add = FOV_BEHIND
 
 /obj/item/clothing/head/roguetown/helmet/nochelm
@@ -656,7 +654,6 @@
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES|MOUTH
-	armor_class = ARMOR_CLASS_MEDIUM
 	block2add = FOV_BEHIND
 
 /obj/item/clothing/head/roguetown/helmet/necrahelm
@@ -668,7 +665,6 @@
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES|MOUTH
-	armor_class = ARMOR_CLASS_MEDIUM
 	block2add = FOV_BEHIND
 
 /obj/item/clothing/head/roguetown/helmet/dendorhelm
@@ -680,7 +676,6 @@
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES|MOUTH
-	armor_class = ARMOR_CLASS_MEDIUM
 	block2add = FOV_BEHIND
 
 /obj/item/clothing/head/roguetown/helmet/heavy
@@ -693,7 +688,6 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	armor = list("blunt" = 90, "slash" = 100, "stab" = 80, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST)
-	armor_class = ARMOR_CLASS_HEAVY
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	max_integrity = 400
@@ -742,7 +736,6 @@
 	emote_environment = 3
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR
 	block2add = FOV_BEHIND
-	armor_class = ARMOR_CLASS_MEDIUM	//breaks the 'scheme' of armor class, because it's a unqiue helm, that can't be remade. Go forth, gatemaster.
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/clothing/head/roguetown/helmet/heavy/knight
@@ -1061,7 +1054,6 @@
 	emote_environment = 3
 	body_parts_covered = HEAD|HAIR|EARS
 	flags_inv = HIDEHAIR
-	armor_class = ARMOR_CLASS_MEDIUM
 	block2add = FOV_BEHIND
 
 /obj/item/clothing/head/roguetown/helmet/bascinet/helmetbars

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -255,7 +255,6 @@
 	icon_state = "plate_legs"
 	item_state = "plate_legs"
 //	adjustable = CAN_CADJUST
-	armor_class = ARMOR_CLASS_MEDIUM
 	sewrepair = FALSE
 	armor = list("blunt" = 90, "slash" = 100, "stab" = 80, "bullet" = 50, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)

--- a/code/modules/clothing/rogueclothes/pants.dm
+++ b/code/modules/clothing/rogueclothes/pants.dm
@@ -255,7 +255,7 @@
 	icon_state = "plate_legs"
 	item_state = "plate_legs"
 //	adjustable = CAN_CADJUST
-	armor_class = ARMOR_CLASS_HEAVY
+	armor_class = ARMOR_CLASS_MEDIUM
 	sewrepair = FALSE
 	armor = list("blunt" = 90, "slash" = 100, "stab" = 80, "bullet" = 50, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)

--- a/code/modules/jobs/job_types/roguetown/church/mortician.dm
+++ b/code/modules/jobs/job_types/roguetown/church/mortician.dm
@@ -1,4 +1,4 @@
-IUM/datum/job/roguetown/undertaker
+/datum/job/roguetown/undertaker
 	title = "Gravesinger"
 	flag = GRAVEDIGGER
 	department_flag = CHURCHMEN

--- a/code/modules/jobs/job_types/roguetown/church/mortician.dm
+++ b/code/modules/jobs/job_types/roguetown/church/mortician.dm
@@ -1,4 +1,4 @@
-/datum/job/roguetown/undertaker
+IUM/datum/job/roguetown/undertaker
 	title = "Gravesinger"
 	flag = GRAVEDIGGER
 	department_flag = CHURCHMEN
@@ -70,7 +70,7 @@
 	ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SIXTHSENSE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SEESPIRITS, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	H.update_sight()
 	H.cmode_music = 'sound/music/combat_clergy.ogg'
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Some sweeping balance changes were made recently by another maintainer in a way that did not allow for required review. As a result, these specific changes are being reverted effective immediately, in lieu of the review I would otherwise have performed. This is the only type of situation outside of an emergency bug or crash fix in which I will be exercising my executive authority as head maintainer to approve a PR that I have authored.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The recent, unapproved addition of medium or heavy armor class to helmets and plated chausses has caused all of these items to prevent the use of Dodge Expert with them, when that is only meant to apply to armor worn on the torso, which can stack with other armor worn on the torso to create a lot of overlapping armor zones. This is why armor class only applies to armor that can be worn in the shirt or torso armor slots.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->