### PR TITLE
Tough quirk reversion changes(+ slight buff) + Unarmed Quirk Buff + New Quirk: "Charger"

### DIFF
--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -19,12 +19,22 @@
 
 /datum/quirk/thickskin
 	name = "Tough" //probably perfect for raw power classes, strange for unrelated ones but i guess.
-	desc = "I am like a dwarven war machine, untiring, unforgiving, unstoppable."
-	value = 3
+	desc = "I can take more beatings than others and my defensive stance will never make me tired!"
+	value = 4
 
 /datum/quirk/thickskin/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	ADD_TRAIT(H, TRAIT_BREADY, QUIRK_TRAIT)
+	H.change_stat("constitution", 2)
+
+/datum/quirk/charger
+	name = "Charger"
+	desc = "I am an unstoppable force, whoever gets on my way I will make them fall to me!"
+	value = 3
+
+/datum/quirk/charger/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder	
+	ADD_TRAIT(H, TRAIT_CHARGER, QUIRK_TRAIT)
 	H.change_stat("constitution", 1)
 
 /datum/quirk/curseofcain

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -159,7 +159,7 @@
 
 /datum/quirk/training9
 	name = "Unarmed Training"
-	desc = "I have journeyman unarmed training and stashed some dusters."
+	desc = "I have journeyman unarmed training and stashed some dusters. My punches also hit harder."
 	value = 4
 
 /datum/quirk/training9/on_spawn()

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -20,13 +20,11 @@
 /datum/quirk/thickskin
 	name = "Tough" //probably perfect for raw power classes, strange for unrelated ones but i guess.
 	desc = "I am like a dwarven war machine, untiring, unforgiving, unstoppable."
-	value = 6
+	value = 3
 
 /datum/quirk/thickskin/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	ADD_TRAIT(H, TRAIT_BREADY, QUIRK_TRAIT)
-	ADD_TRAIT(H, TRAIT_PUGILIST, QUIRK_TRAIT)
-	ADD_TRAIT(H, TRAIT_CHARGER, QUIRK_TRAIT)
 	H.change_stat("constitution", 1)
 
 /datum/quirk/curseofcain
@@ -162,13 +160,14 @@
 /datum/quirk/training9
 	name = "Unarmed Training"
 	desc = "I have journeyman unarmed training and stashed some dusters."
-	value = 2
+	value = 4
 
 /datum/quirk/training9/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
 	H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
 	H.mind.special_items["Dusters"] = /obj/item/rogueweapon/duster
+	ADD_TRAIT(H, TRAIT_PUGILIST, QUIRK_TRAIT)
 
 /datum/quirk/mtraining1
 	name = "Medical Training"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Tough quirk should stay as it is, why should being a tough cookie who never tires from being in defensive stance makes someone automatically a good puncher... And charge at people like a NFL player? Reverted its changed and costs from 6 points to <s>3 again</s>4, and granting 2 Constitution points instead of 1.

Speaking of punching, Unarmed Training gets a buff with TRAIT_PUGILIST, but it's quirk cost increases from 2 to 4

## Why It's Good For The Game

Sorry Vide, I know your intention was to make Tough a less trash positive quirk, but in my opinion, the pugilist trait should belong to Unarmed Training quirk instead.

Edit THU,DEC15TH: Charger has been created as a quirk instead of merging it with Tough, costing 3 quirk points, granting charger trait and 1 point of Costitution. I gave Tough one extra Constitution point but increased its cost from 3 to 4.