### PR TITLE
Spell Deselecting When On Cooldown

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -544,10 +544,11 @@
 	return ..()
 
 /datum/action/spell_action/Trigger()
-	if(!..())
-		return FALSE
 	if(target)
 		var/obj/effect/proc_holder/S = target
+		if(!..())
+			S.deactivate(usr)
+			return FALSE
 		S.Click()
 		return TRUE
 

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -164,11 +164,11 @@
 		if(HAS_TRAIT(target, TRAIT_ASTRATA_CURSE))
 			target.visible_message(span_danger("[target] recoils in pain!"), span_userdanger("Divine healing shuns me!"))
 			target.cursed_freak_out()
-			return FALSE
+			return TRUE
 		if(HAS_TRAIT(target, TRAIT_ATHEISM_CURSE))
 			target.visible_message(span_danger("[target] recoils in disgust!"), span_userdanger("These fools are trying to cure me with religion!!"))
 			target.cursed_freak_out()
-			return FALSE
+			return TRUE
 		target.visible_message(span_info("A wreath of gentle light passes over [target]!"), span_notice("I'm bathed in holy light!"))
 		if(iscarbon(target))
 			var/mob/living/carbon/C = target
@@ -253,7 +253,7 @@
 		return TRUE
 	return FALSE
 
-/obj/effect/proc_holder/spell/targeted/stable/cast(list/targets, mob/user) 
+/obj/effect/proc_holder/spell/targeted/stable/cast(list/targets, mob/user)
 	. = ..()
 	if(iscarbon(targets[1]))
 		var/mob/living/carbon/target = targets[1]
@@ -268,7 +268,7 @@
 		return TRUE
 	return FALSE
 
-/obj/effect/proc_holder/spell/targeted/purge/cast(list/targets, mob/user) 
+/obj/effect/proc_holder/spell/targeted/purge/cast(list/targets, mob/user)
 	. = ..()
 	if(iscarbon(targets[1]))
 		var/mob/living/carbon/target = targets[1]

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -429,6 +429,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		if(action)
 			action.UpdateButtonIcon()
 		return TRUE
+	revert_cast(user) //Failed. Don't consume the spell.
 	return FALSE
 
 /obj/effect/proc_holder/spell/proc/before_cast(list/targets, mob/user = usr)


### PR DESCRIPTION
you can now select spells even if they are on cooldown

if you fail to cast a spell (misclicked) it will not go on cooldown