### PR TITLE
Re-Adds PROSPERO to Map

### DIFF
--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -17042,7 +17042,7 @@
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
 	},
-/obj/structure/roguemachine/wizardvend/academy,
+/obj/structure/roguemachine/wizardvend,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/library)
 "msJ" = (


### PR DESCRIPTION
oopsie. I forgot to put PROSPERO back on the map after I gave up on ARIEL changes for the 166 PR and only now just realized it because I was trying to hunt for the reason why commits keep getting merge conflict check fails, but I honestly think it's because of the github bot or a change like 15 commits ago so it may just need to be fixed by modifying the checkbot.