### PR TITLE
Archmage slots to 3

### DIFF
--- a/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
+++ b/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
@@ -4,8 +4,8 @@
 	department_flag = ACADEMY
 	selection_color = JCOLOR_ACADEMY
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 1
+	spawn_positions = 1
 
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_sexes = list(MALE, FEMALE)

--- a/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
+++ b/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
@@ -4,8 +4,8 @@
 	department_flag = ACADEMY
 	selection_color = JCOLOR_ACADEMY
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_sexes = list(MALE, FEMALE)

--- a/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
+++ b/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
@@ -4,8 +4,8 @@
 	department_flag = ACADEMY
 	selection_color = JCOLOR_ACADEMY
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 
 	allowed_races = RACES_ALL_KINDSPLUS
 	allowed_sexes = list(MALE, FEMALE)


### PR DESCRIPTION
## About The Pull Request

PR title.

## Why It's Good For The Game

This guy is as strong as the Guildmaster and Innkeep. Stats are fine as an OP leadership role, but five slots is insane. We don't need a brigade of archmages with master weapon skill and templar stats. Doesn't really make sense anyway, five headmasters and three normal wizards...

One slot for each of the three mastery types. Personally I would make 1 slot for each of the three archmage choices instead of doing the stupid book of memories thing. If the choices are supposed to be professors in different classes or something that would make more sense than potentially having three spellblade masters and no evokers.