### PR TITLE
fixes two improperly defined recipes

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -760,14 +760,14 @@
 	amount = 3
 	firefuel = 60 MINUTES
 
-/datum/crafting_recipe/roguetown/bandage
+/datum/crafting_recipe/roguetown/puress
 	name = "essence of purity"
 	result = /obj/item/reagent_containers/powder/alch/pur
 	reqs = list(/obj/item/reagent_containers/powder/salt = 1, /obj/item/reagent_containers/powder/alch/pipe = 1,)
 	craftdiff = 5
 	skillcraft = /datum/skill/misc/alchemy
 
-/datum/crafting_recipe/roguetown/bandage
+/datum/crafting_recipe/roguetown/lifeess
 	name = "essence of life"
 	result = /obj/item/reagent_containers/powder/alch/life
 	reqs = list(/obj/item/reagent_containers/powder/salt = 1, /datum/reagent/medicine/healthpot = 45, /obj/item/reagent_containers/powder/alch/mincem = 1,)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Basically two of the alchemy recipes were improperly typed as bandage recipes, causing them to be nonfunctional.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->