### PR TITLE
Magicians can properly use scrolls again

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -294,7 +294,7 @@
 
 /obj/item/book/granter/spell/dropped(mob/user, silent)
 	. = ..()
-	if(spell && castable && HAS_TRAIT(user, TRAIT_USEMAGIC)) && !user_has_spell_already)
+	if(spell && castable && HAS_TRAIT(user, TRAIT_USEMAGIC) && !user_has_spell_already)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.mind)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -282,7 +282,7 @@
 
 /obj/item/book/granter/spell/equipped(mob/user, slot, initial)
 	. = ..()
-	if(spell && castable && (HAS_TRAIT(user, TRAIT_USEMAGIC) || HAS_TRAIT(user, TRAIT_LEARNMAGIC)))
+	if(spell && castable && HAS_TRAIT(user, TRAIT_USEMAGIC))
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
@@ -294,7 +294,7 @@
 
 /obj/item/book/granter/spell/dropped(mob/user, silent)
 	. = ..()
-	if(spell && castable && (HAS_TRAIT(user, TRAIT_USEMAGIC) || HAS_TRAIT(user, TRAIT_LEARNMAGIC)) && !user_has_spell_already)
+	if(spell && castable && HAS_TRAIT(user, TRAIT_USEMAGIC)) && !user_has_spell_already)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.mind)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -271,7 +271,7 @@
 	//Can this be one-casted by non learnables?
 	var/castable = TRUE
 	var/usable_times = 3
-	required_trait = TRAIT_USEMAGIC
+	required_trait = TRAIT_
 	required_learn_trait = TRAIT_LEARNMAGIC
 	//should help us not remove spells from people that have em memorized.
 	var/user_has_spell_already = FALSE

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -271,7 +271,7 @@
 	//Can this be one-casted by non learnables?
 	var/castable = TRUE
 	var/usable_times = 3
-	required_trait = TRAIT_
+	required_trait = TRAIT_USEMAGIC
 	required_learn_trait = TRAIT_LEARNMAGIC
 	//should help us not remove spells from people that have em memorized.
 	var/user_has_spell_already = FALSE


### PR DESCRIPTION
## About The Pull Request

Anyone who can fully learn magic can no longer use scrolls directly for individual casts. They must read them to learn the spell fully.
This will fix issues with magicians forgetting spells they already know, being incapable of learning magic, etc.

## Why It's Good For The Game

Mages being exactly as capable as rogues when it comes to magic was something Vide's entire PR was meant to prevent.

This is intended as a temporary fix so that the game functions properly until Vide actually fixes their code. I will not be happy if Vide closes this PR saying "I'm working on it" and then takes another ten hours to actually PR a fix.