### PR TITLE
Bandages should properly heal wounds when applied

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -723,7 +723,8 @@
 
 /proc/heal_and_manage_pain_disabling(mob/living/carbon/human/H, obj/item/bodypart/affecting)
 	if (!affecting) return
-	affecting.heal_wounds(0.5)
+	if(prob(50))
+		affecting.heal_wounds(1)
 	for (var/datum/wound/W in affecting.wounds)
 		if (W.woundpain > 30)
 			W.woundpain = 30


### PR DESCRIPTION
## About The Pull Request

Bug fix, technically. 50% chance of healing 1 wounds per tick. Intended to heal 0.5 wounds every tick.

## Why It's Good For The Game

Bug fixes are generally good.

The issue here: Wounds work off of integers, I'm pretty sure. 1 is the lowest amount you can heal wounds by without being truncated to 0. So trying to heal 0.5 wounds per tick does nothing.

This will result in an identical wound heal rate to minor health potions, which use the same workaround.