### PR TITLE
Fixes slop-lore related typos

### DIFF
--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -257,7 +257,7 @@
 
 /obj/item/reagent_containers/powder/sublimate // Gotten through alchemy, combine milled gemstone with moondust. Higher value dust, more sublimate.
 	name = "arcyne sublimate"
-	desc = "The stuff of gizaels and magic."
+	desc = "The stuff of jewels and magic."
 	gender = PLURAL
 	icon = 'icons/roguetown/items/gems.dmi'
 	icon_state = "sublimate"

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -966,7 +966,7 @@
 /obj/item/clothing/suit/roguetown/armor/plate/spellslingerarmor
 	slot_flags = ITEM_SLOT_ARMOR
 	name = "spellslinger cuirass"
-	desc = "Armor of a spellslinger. Studded with a variety of sapphiras and other prized gizaels; this is truly the armor of a magician. Known to cause a heavy toll on the user..."
+	desc = "Armor of a spellslinger. Studded with a variety of sapphires and other prized jewels; this is truly the armor of a magician. Known to cause a heavy toll on the user..."
 	body_parts_covered = CHEST|VITALS|GROIN|NECK
 	icon_state = "spellslingerarmor" // No gendered/dwarf sprites
 	item_state = "spellslingerarmor"


### PR DESCRIPTION
## About The Pull Request

Changes two instances of "gizael" to "jewel".
Also changes one instance of "sapphira" to "sapphire" because we don't use the stupid fantasy gemstone names here.

## Why It's Good For The Game

Obviously this is related to the Giza = fantasy Jews thing Blackstone (and maybe even Roguetown, IDK) had going on. I assume someone did a shitty find-and-replace job at some point from Jew to Giza and these descriptions got changed to have a nonsense word.

For the record, the word "jewel" is not actually related to the word "Jew" in real life. So if this _was_ intentional, whoever did it is an idiot. If the Giza slop lore didn't make that clear on its own, anyway.