### PR TITLE
Clockwork Right Leg is now properly smithable

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
@@ -323,6 +323,7 @@
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/bodypart/r_leg/rprosthetic/clock
 	additional_items = list(/obj/item/roguegear,/obj/item/roguegear,/obj/item/roguegear)
+	i_type = "General"
 
 /datum/anvil_recipe/tools/alembic        ////////// yes I know the sprites copper. chill.
 	name = "Alembic"


### PR DESCRIPTION
## About The Pull Request

Someone forgot to give the Clockwork Leg (R) crafting recipe a category on the anvil, so you can't currently craft it.

## Why It's Good For The Game

Sample text.
