### PR TITLE
Fixes the spell slot system

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -320,6 +320,7 @@
 	to_chat(user, span_notice("I start reading about casting [spellname]..."))
 
 /obj/item/book/granter/spell/on_reading_finished(mob/living/user)
+	user.calculate_spell_slots()
 	if(user.spell_slots - spell_slot_cost >= 0)
 		to_chat(user, span_notice("I feel like you've experienced enough to cast [spellname]!"))
 		var/obj/effect/proc_holder/spell/S = new spell

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -320,7 +320,7 @@
 	to_chat(user, span_notice("I start reading about casting [spellname]..."))
 
 /obj/item/book/granter/spell/on_reading_finished(mob/living/user)
-	if(user.spell_slots - spell_slot_cost < 0)
+	if(user.spell_slots - spell_slot_cost >= 0)
 		to_chat(user, span_notice("I feel like you've experienced enough to cast [spellname]!"))
 		var/obj/effect/proc_holder/spell/S = new spell
 		user.spell_slots_used += 1


### PR DESCRIPTION
## About The Pull Request

Spell slot system currently checks if your spell slot total is _below_ zero, not above zero. It also doesn't actually set your spell slots until after the first scroll you use, instead using the default value of 0. This leads to a puzzling behavior of learning from the first scroll (because 0-1 < 0) and then never being able to use scrolls again, regardless of current INT or arcane skill, because even an idiot with 5 int and 1 arcane skill will have an unused spell slot, and 1 - 1 !< 0.

This PR flips the calculation so that your spell slots after learning a new spell must be equal to or above zero - meaning you still haven't used one. It also calculates your spell slots before reading a scroll, so it always ensures that your slot total is up to date when trying to learn. This does mean you can use drugs to artificially increase your spell slot total, but you could do that anyway by just using the drugs on the *previous* scroll.

## Why It's Good For The Game

I hope this is self-explanatory.
