### PR TITLE
Two core weapon calculation changes

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -8,9 +8,11 @@
 	if(target.grabbedby == user)
 		if(user.grab_state >= GRAB_AGGRESSIVE)
 			return zone
-	if(!(target.mobility_flags & MOBILITY_STAND))
+	if(!(target.mobility_flags & MOBILITY_STAND)) // Fallen enemies will always be hit in the target zone.
 		return zone
-	if( (target.dir == turn(get_dir(target,user), 180)))
+	if( (target.dir == turn(get_dir(target,user), 180))) // Perfect backstabs always land on target. (This makes no sense for facial features, but whatever.)
+		return zone
+	if(!(target.cmode)) // Someone who isn't alert will let you line up a shot. Maybe this should just be a modifier.
 		return zone
 
 	var/chance2hit = 0
@@ -26,9 +28,8 @@
 			chance2hit += user.STAPER
 		if(used_intent.blade_class == BCLASS_CUT)
 			chance2hit += round(user.STAPER/2)
-		if(used_intent.blade_class == BCLASS_PICK)
-			chance2hit -= 30
-
+		if(used_intent.blade_class == BCLASS_PICK) // Daggers are used on downed people to finish them off, not standing mid-fight. Downed strikes always hit target and ignore accuracy calc (above mobility flag check).
+			chance2hit -= 30 // Because daggers are WLENGTH_SHORT, this is effectively -20 accuracy, then PER, aimed style, and skill come in. Sucks for pickaxe enjoyers, but improvised weapon should be hard to aim.
 
 	if(I)
 		if(I.wlength == WLENGTH_SHORT)

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -26,6 +26,9 @@
 			chance2hit += user.STAPER
 		if(used_intent.blade_class == BCLASS_CUT)
 			chance2hit += round(user.STAPER/2)
+		if(used_intent.blade_class == BCLASS_PICK) // Daggers are used on downed people to finish them off, not standing mid-fight. Downed strikes always hit target and ignore accuracy calc (above mobility flag check).
+			chance2hit -= 30 // Because daggers are WLENGTH_SHORT, this is effectively -20 accuracy, then PER, aim intent, and skill come in. Sucks for pickaxe enjoyers, but improvised weapon should be hard to aim.
+
 
 	if(I)
 		if(I.wlength == WLENGTH_SHORT)
@@ -254,7 +257,7 @@
 					else
 						flash_fullscreen("blackflash2")
 
-					var/dam2take = round((get_complex_damage(AB,user,used_weapon.blade_dulling)/2),1)
+					var/dam2take = round((get_complex_damage(AB,user,used_weapon.blade_dulling)/8),1)
 					if(dam2take)
 						used_weapon.take_damage(max(dam2take,1), BRUTE, used_weapon.d_type)
 					return TRUE

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -26,8 +26,8 @@
 			chance2hit += user.STAPER
 		if(used_intent.blade_class == BCLASS_CUT)
 			chance2hit += round(user.STAPER/2)
-		if(used_intent.blade_class == BCLASS_PICK) // Daggers are used on downed people to finish them off, not standing mid-fight. Downed strikes always hit target and ignore accuracy calc (above mobility flag check).
-			chance2hit -= 30 // Because daggers are WLENGTH_SHORT, this is effectively -20 accuracy, then PER, aim intent, and skill come in. Sucks for pickaxe enjoyers, but improvised weapon should be hard to aim.
+		if(used_intent.blade_class == BCLASS_PICK)
+			chance2hit -= 30
 
 
 	if(I)


### PR DESCRIPTION
## About The Pull Request

PICK intent will result in a -30 to called shot accuracy, making most shots hit chest even with good stats and skill.

Damage inflicted to weapons when parrying is divided by 8 instead of 2, quadrupling durability.

## Why It's Good For The Game

Change 1:

PICK intent is, conceptually, wedging a knife in a downed person's armor to finish them off. It doesn't make sense to be able to do this when they're standing without a lot of skill and luck. Downed targets will always result in a called shot landing because there is an earlier check to skip the aim calculation on non-standing enemies. This does negatively affect pickaxe users, but that's much, much less common than daggers.

Daggers on PICK intent redirected to the chest will still go through the chestplate, but this is still a nerf relative to being able to reliably aim neck or eye or whatever. Aorta is lethal, but less lethal than blinding or perma-stun, and rib fracture does little compared to skull crack. Fixing this (so the knife skids off entirely) would require global chestplate armor buff to 90 stab - which, to be fair, would only really impact daggers as far as I know. And Estoc, but it can't crit through plate armor anyway, so it doesn't care. This might be a future PR from me.

As far as PVE content, this will probably make the Lich harder, but if you're using daggers against his minions instead of maces or something you're SOL in the actual boss fight anyway. Any other armored enemies are simplemobs who don't care about target location.

Change 2:

Right now a steel mace on SMASH intent (66 base dmg) will five-shot a steel sword (150 HP), if the attacker has 10 STR. Mobs like goblins use iron maces on STRIKE intent (30 base dmg), which is still only ten hits - again, with 10 STR. This causes problems in both PVE and PVP. Weapons explode a comical amount. This change will make your weapon shattering much more likely to be because of bad maintenance over a long period of time and not a single fight against a single enemy using a blunt weapon. May help lower the playerbase's fixation on wanting to be jack-of-all-trades carrying around a blacksmith hammer at all times.

Note that because of dulling class weirdness, non-blunt weapons already did 0 damage to parrying weapons anyway, as far as I can tell. So this change generally only affects maces, flails, and... for some reason, daggers on pick intent also do damage to weapons when parrying.

This change will have no effect on durability loss caused by attacking enemies or objects with weapons; that damage is handled separately. The reduction only applies specifically to parrying attacks that would normally cause damage to the blocking weapon.