### PR TITLE
Fix Smithy Apprentice Loadout

### DIFF
--- a/code/modules/jobs/job_types/roguetown/apprentices/smith_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/apprentices/smith_apprentice.dm
@@ -41,7 +41,7 @@
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		beltr = /obj/item/roguekey/blacksmith/town
+		beltr = /obj/item/roguekey/blacksmith
 		cloak = /obj/item/clothing/cloak/apron/brown
 		backr = /obj/item/storage/backpack/rogue/satchel
 		backpack_contents = list(/obj/item/rogueweapon/hammer = 1, /obj/item/rogueweapon/tongs = 1)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Female apprentice smiths got a different key type from their male counterparts AND the other smiths. This fixes that, giving them the standard blacksmith key. Tested in game, just to be sure.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of life/bug fix. Let them INSIDE the smithy.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
