### PR TITLE
Vore Tab Hidden Behind Quirk

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -63,7 +63,7 @@
 #define TRAIT_CHARGER "Charger" //advantage on running into people.
 #define TRAIT_ARTIFICER "Artificer" //after casting some spells, hurl a firebolt at the same location
 #define TRAIT_NODETECT "Nondetection" //You can not be scryed on
-#define TRAIT_VORACIOUS "Voracious" //can access vore
+#define TRAIT_VORE "Vore" //can access vore
 //Hearthstone end.
 
 // PATRON GOD TRAITS

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -63,6 +63,7 @@
 #define TRAIT_CHARGER "Charger" //advantage on running into people.
 #define TRAIT_ARTIFICER "Artificer" //after casting some spells, hurl a firebolt at the same location
 #define TRAIT_NODETECT "Nondetection" //You can not be scryed on
+#define TRAIT_VORACIOUS "Voracious" //can access vore
 //Hearthstone end.
 
 // PATRON GOD TRAITS

--- a/modular_causticcove/code/modules/vore/eating/vore_misc.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_misc.dm
@@ -2,6 +2,17 @@
 	//oh no vore time
 	var/voremode = FALSE
 
+//idk why it was defined so these verbs are automatically on everyone, including NPCS, but in order to avoid changing 900 lines of code, all vore verbs are deleted from mob @ roundstart. voracious quirk readds them.
+/mob/living/Initialize()
+    . = ..()
+    verbs -= list(
+        /mob/living/carbon/verb/toggle_vore_mode_verb,
+        /mob/living/verb/insidePanel,
+        /mob/living/verb/escapeOOC,
+        /mob/living/verb/lick,
+        /mob/living/verb/preyloop_refresh
+    )
+
 /mob/living/proc/toggle_vore_mode()
 	if(cmode)
 		return FALSE

--- a/modular_causticcove/code/modules/vore/eating/vore_misc.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_misc.dm
@@ -2,7 +2,7 @@
 	//oh no vore time
 	var/voremode = FALSE
 
-//idk why it was defined so these verbs are automatically on everyone, including NPCS, but in order to avoid changing 900 lines of code, all vore verbs are deleted from mob @ roundstart. voracious quirk readds them.
+//idk why it was defined so these verbs are automatically on everyone, including NPCS, but in order to avoid changing 900 lines of code, all vore verbs are deleted from mob @ roundstart. vore quirk readds them.
 /mob/living/Initialize()
     . = ..()
     verbs -= list(

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -623,3 +623,34 @@
 /datum/quirk/endowedlite/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.apply_status_effect(/datum/status_effect/debuff/bigboobs/permanent/lite)
+
+/datum/quirk/voracious
+    name = "Voracious"
+    desc = "You can engage in Vore."
+    value = 0
+    mob_trait = TRAIT_VORACIOUS
+
+/datum/quirk/voracious/add()
+    var/mob/living/carbon/human/H = quirk_holder
+    var/list/vore_verbs = list(
+        /mob/living/carbon/verb/toggle_vore_mode_verb,
+        /mob/living/verb/insidePanel,
+        /mob/living/verb/escapeOOC,
+        /mob/living/verb/lick,
+        /mob/living/verb/preyloop_refresh
+    )
+    H.verbs |= vore_verbs
+    H.vore_flags |= SHOW_VORE_PREFS
+
+/datum/quirk/voracious/remove()
+    var/mob/living/carbon/human/H = quirk_holder
+    var/list/vore_verbs = list(
+        /mob/living/carbon/verb/toggle_vore_mode_verb,
+        /mob/living/verb/insidePanel,
+        /mob/living/verb/escapeOOC,
+        /mob/living/verb/lick,
+        /mob/living/verb/preyloop_refresh
+    )
+    H.verbs -= vore_verbs
+    H.vore_flags &= ~SHOW_VORE_PREFS
+    H.disable_vore_mode()

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -624,13 +624,13 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	H.apply_status_effect(/datum/status_effect/debuff/bigboobs/permanent/lite)
 
-/datum/quirk/voracious
-    name = "Voracious"
+/datum/quirk/vore
+    name = "Vore"
     desc = "You can engage in Vore."
     value = 0
-    mob_trait = TRAIT_VORACIOUS
+    mob_trait = TRAIT_VORE
 
-/datum/quirk/voracious/add()
+/datum/quirk/vore/add()
     var/mob/living/carbon/human/H = quirk_holder
     var/list/vore_verbs = list(
         /mob/living/carbon/verb/toggle_vore_mode_verb,
@@ -642,7 +642,7 @@
     H.verbs |= vore_verbs
     H.vore_flags |= SHOW_VORE_PREFS
 
-/datum/quirk/voracious/remove()
+/datum/quirk/vore/remove()
     var/mob/living/carbon/human/H = quirk_holder
     var/list/vore_verbs = list(
         /mob/living/carbon/verb/toggle_vore_mode_verb,


### PR DESCRIPTION
## About The Pull Request

due to overwhelming player feedback the vore panel has been hidden behind a quirk. this solves everyone's issues that have been brought up in general. i have no personal opinion on anything here i'm just executing the will of the playerbase.

## Why It's Good For The Game

because player feedback = good and because it changes nothing but allowing people to consent into engaging with the vore system, rather than it automatically being applicable. also pretty sure it'll reduce start-time and help with server chug cause now NPCs won't have the verbs.
