### PR TITLE
Charge Nerfs/Changes

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -187,13 +187,13 @@
 
 			var/mob/living/L = M
 
-			var/self_points = FLOOR((STACON + STASTR + mind.get_skill_level(/datum/skill/misc/athletics))/2, 1)
+			var/self_points = FLOOR((STAEND + STASTR + mind.get_skill_level(/datum/skill/misc/athletics))/2, 1) //Constitution had too many quirk bonuses associated.
 			var/target_points = FLOOR((L.STAEND + L.STASTR + L.mind.get_skill_level(/datum/skill/misc/athletics))/2, 1)
 
 			switch(sprint_distance)
 				// Point blank
 				if(0 to 1)
-					self_points -= 4
+					self_points -= 5
 				// One to two tiles between people - this is the main combat case.
 				if(2 to 3)
 					self_points -= 2
@@ -206,8 +206,11 @@
 				self_points += 2
 
 			// Ratwood does not have artificer, but we do. Numbers are basically the same so I'm keeping the old bonus.
+			// Being prone here gets you sneak attacked for 2x to 8x damage, so Charger is +2.
 			if(HAS_TRAIT(src, TRAIT_CHARGER))
-				self_points += 3
+				self_points += 2
+			if(HAS_TRAIT(L, TRAIT_CHARGER))
+				target_points += 2
 
 			// Ratwood has RNG here. No thanks.
 
@@ -1051,7 +1054,7 @@
 		log_combat(src, pulledby, "resisted grab")
 		resist_grab()
 		return
-	
+
 	// CIT CHANGE - climbing out of a gut.
 	if(vore_process_resist())
 		//Sure, give clickdelay for anti spam. shouldn't be combat voring anyways.


### PR DESCRIPTION
## About The Pull Request
Nerfs pointblank charging further, changes the contested charging formula to use endurance for both sides instead of just for the defender, slightly nerfs the charger trait, charger trait now applies on defending against charges as well.

## Why It's Good For The Game
- Charging was a major point of complaint from players, due to how easy it was to minmaxx the relevant stats (Constitution and Strenght) through preference quirks such as Giant and Endowment Curse. To worsen things, when defending against a charge, Endurance was used instead of Constitution, which had zero quirks increasing it and was a more uncommon stat. Being prone also made you get 'sneak attacked' for a damage multiplier of up to 7x, turning charges into instant fight enders.
- With charging using Endurance on both sides, the only quirks/traits that buff it are now Charger and Giant. Furthermore, Charger applies on defense, maintaining parity on calculations. Pointblank (0 to 1 tile) charges have been further nerfed, and the Charger trait pegged down from a virtual +6 strenght to +4 strenght for charge calculations.
