### PR TITLE
Upper Skill Gain Nerf

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -11,9 +11,9 @@
 #define SKILL_EXP_NOVICE 50
 #define SKILL_EXP_APPRENTICE 150
 #define SKILL_EXP_JOURNEYMAN 275
-#define SKILL_EXP_EXPERT 625
-#define SKILL_EXP_MASTER 1200
-#define SKILL_EXP_LEGENDARY 2200
+#define SKILL_EXP_EXPERT 1250
+#define SKILL_EXP_MASTER 3600
+#define SKILL_EXP_LEGENDARY 8800
 
 // Gets the reference for the skill type that was given
 #define GetSkillRef(A) (SSskills.all_skills[A])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Widen the exp needed to gain a skill on the latter half (Expert, Master, Legendary) by a significant margin, keep the easy to train skills (novice, apprentice, journeyman) the same


## Why It's Good For The Game

While people are 100% insistent on being self sufficient on skills, It shouldn't mean that they should be stepping on roles who's sole purpose is that skill (Smiths, Alchemist, Seamster/Seamstress, etc)

You'll still be allowed to craft the gear you want, but if you want quality gear, you will have to work for it, a lot, or go to a professional

(Crafters deserve to feel special too)
