### PR TITLE
Fixes mortar and pestles giving a thing's whole reagent list

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -636,6 +636,16 @@
 				grinded.on_juice()
 				reagents.add_reagent_list(grinded.juice_results)
 				to_chat(user, "I juice [grinded] into a fine liquid.")
+				icon_state = reagents.total_volume > 0 ? "mortar_full" : "mortar_empty"
+				grinding_started = FALSE // Reset grinding status
+				return
+			if(grinded.grind_results)
+				grinded.on_grind()
+				reagents.add_reagent_list(grinded.grind_results)
+				to_chat(user, "I grind [grinded] into a fine powder.")
+				icon_state = reagents.total_volume > 0 ? "mortar_full" : "mortar_empty"
+				grinding_started = FALSE // Reset grinding status
+				return
 			if(grinded.reagents) // Food and pills.
 				grinded.reagents.trans_to(src, grinded.reagents.total_volume, transfered_by = user)
 				QDEL_NULL(grinded)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Previously, when grinding down things like rocknuts for coffee, you couldn't make pure coffee, since it always gave some extra nutriment and nicotine. Now, mortars and pestles check if the thing has a grind_result and outputs that instead.

Coffee, hooray