### PR TITLE
Buff chop damage for swords

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -400,7 +400,7 @@
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	penfactor = 10
 	swingdelay = 8
-	damfactor = 0.8
+	damfactor = 1.1
 	item_d_type = "slash"
 
 /datum/intent/sword/chop/falchion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

change the damage modifer for chop from 0.8 (80%) of force to 1.1 (110% of force)

## Why It's Good For The Game

Why was the slow windup attack given a 20% dmg nerf in the first place
Sure it has a better chance to delimb, but the 20% dmg nerf makes that bonus pointless

As an in-game example, the greatsword deals 30 force, against leather armor. A zweihander will chop for 14.4 cut damage, at a 1 tile range.
At the same time, the same zweihander will cut for 15 cut damage, at a 2 tile range.
Post change, the zwei will now chop for 19.8 dmg, while at the same time, not stepping on the falchions 1.2 modifiers toes. 