### PR TITLE
Head Fractures and Critical Weakness

### DIFF
--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -3,9 +3,9 @@
 	check_name = span_bone("<B>FRACTURE</B>")
 	severity = WOUND_SEVERITY_SEVERE
 	crit_message = list(
-		"The bone shatters!", 
-		"The bone is broken!", 
-		"The %BODYPART is mauled!", 
+		"The bone shatters!",
+		"The bone is broken!",
+		"The %BODYPART is mauled!",
 		"The bone snaps through the skin!",
 	)
 	sound_effect = "wetbreak"
@@ -52,9 +52,9 @@
 	name = "cranial fracture"
 	check_name = span_bone("<B>SKULLCRACK</B>")
 	crit_message = list(
-		"The skull shatters in a gruesome way!", 
-		"The head is smashed!", 
-		"The skull is broken!", 
+		"The skull shatters in a gruesome way!",
+		"The head is smashed!",
+		"The skull is broken!",
 		"The skull caves in!",
 	)
 	sound_effect = "headcrush"
@@ -82,7 +82,7 @@
 		if(iscarbon(affected))
 			var/mob/living/carbon/carbon_affected = affected
 			carbon_affected.update_disabled_bodyparts()
-	if(mortal || HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
+	if(mortal && HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
 		affected.death()
 
 /datum/wound/fracture/head/on_mob_loss(mob/living/affected)
@@ -152,9 +152,9 @@
 	name = "mandibular fracture"
 	check_name = span_bone("JAW FRACTURE")
 	crit_message = list(
-		"The mandible comes apart beautifully!", 
-		"The jaw is smashed!", 
-		"The jaw is shattered!", 
+		"The mandible comes apart beautifully!",
+		"The jaw is smashed!",
+		"The jaw is shattered!",
 		"The jaw caves in!",
 	)
 	whp = 80
@@ -174,7 +174,7 @@
 	name = "cervical fracture"
 	check_name = span_bone("<B>NECK</B>")
 	crit_message = list(
-		"The spine shatters in a spectacular way!", 
+		"The spine shatters in a spectacular way!",
 		"The spine snaps!",
 		"The spine cracks!",
 		"The spine is broken!",
@@ -226,9 +226,9 @@
 	name = "pelvic fracture"
 	check_name = span_bone("<B>PELVIS</B>")
 	crit_message = list(
-		"The pelvis shatters in a magnificent way!", 
-		"The pelvis is smashed!", 
-		"The pelvis is mauled!", 
+		"The pelvis shatters in a magnificent way!",
+		"The pelvis is smashed!",
+		"The pelvis is mauled!",
 		"The pelvic floor caves in!",
 	)
 	whp = 50
@@ -240,7 +240,7 @@
 		name = "broken buck"
 		check_name = span_bone("BUCKBROKEN")
 		crit_message = "The buck is broken expertly!"
-	
+
 /datum/wound/fracture/groin/on_mob_gain(mob/living/affected)
 	. = ..()
 	affected.Stun(20)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -411,7 +411,7 @@
 						attempted_wounds +=/datum/wound/fracture/head/nose
 					else
 						attempted_wounds += /datum/wound/facial/disfigurement/nose
-				else if(zone_precise in knockout_zones)
+				else if(zone_precise == BODY_ZONE_PRECISE_SKULL)
 					attempted_wounds += /datum/wound/fracture/head/brain
 
 	for(var/wound_type in shuffle(attempted_wounds))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Changes stab cranium fracture to only happen on skull rather than both skull and head zone and adjusts it so not all head fractures instantly kill those with critical weakness (neck, eye and ear fractures still kill them instantly).

## Why It's Good For The Game

It's impossible to attempt to knock out a vampire right now or even punch them in the head, really, without risking instantly killing them on the spot, which is made worse by the fact that only a necromancer can even bring them back.

This should let vampires still be killable by those who want to kill them but stop any single head punch in a bar fight or spar from potentially roundremoving you.
