### PR TITLE
Bounty Collar + Druid Amulet Fix + Enchanted Bounty Scroll

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -197,23 +197,23 @@
 		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
 /obj/item/clothing/neck/roguetown/gorget/prisoner/canStrip(mob/living/carbon/human/stripper, mob/living/carbon/human/owner)
-	if(usr.job == "Hedgemaster" || usr.job == "Hedge Knight")
-		to_chat(usr, span_warning("I disable the collar's unremovableness curse... It will only reactivate when worn again."))
+	if(usr.job == "Great Druid" || usr.job == "Druid" || usr.job == "Hedge Warden" || usr.job == "Hedge Knight" || usr.job == "Ovate")
+		to_chat(usr, span_warning("I disable the collar's enchanted locking mechanism. It will only reactivate when worn again."))
 		REMOVE_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 		return TRUE
 	else
 		return ..()
 
 /obj/item/clothing/neck/roguetown/gorget/prisoner/servant
-	name = "cursed obedience collar"
-	desc = "This collar makes me obligated to heed to orders of others. And prevents me from running away..."
+	name = "enchanted bounty-collar"
+	desc = "This collar makes me obligated to heed to orders from the citizens of the Town, and restricts my movements..."
 
 /obj/item/clothing/neck/roguetown/gorget/prisoner/servant/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot == SLOT_NECK)
 		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 		ADD_TRAIT(user, TRAIT_PACIFISM, CURSED_ITEM_TRAIT)
-		to_chat(user, span_warning("This collar makes me heed to orders of others, unless it includes self harm or orders that will indirectly or directly harm to town and its population... And also it prevents me from running away..."))
+		to_chat(user, span_warning("This collar makes me heed to orders from the citizens of the Town, unless those orders will result in self harm, forced sexual interactions, or orders that will indirectly or directly harm the town or its population. It also restricts my movement."))
 		to_chat(user, span_alert("Roleplay accordingly to your collar's effects."))
 
 /obj/item/clothing/neck/roguetown/gorget/prisoner/dropped(mob/user)

--- a/code/modules/roguetown/roguemachine/bounty.dm
+++ b/code/modules/roguetown/roguemachine/bounty.dm
@@ -225,8 +225,8 @@
 
 
 /obj/structure/chair/arrestchair
-	name = "SLAVEMASTER"
-	desc = "A chairesque machine that collects bounties through enslavement rather than death, for a much greater reward."
+	name = "BOUNTYMASTER"
+	desc = "A chairesque machine that collects bounties through enslavement to the Town rather than death, for a much greater reward."
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "brass_chair"
 	blade_dulling = DULLING_BASH
@@ -277,11 +277,13 @@
 
 	if(correct_head)
 		say("A bounty has been sated.")
-		budget2change((reward_amount*2)) //double reward for alive
-		var/newcollar = new /obj/item/clothing/neck/roguetown/gorget/prisoner/servant(get_turf(M))
+		budget2change((reward_amount*2))
+		var/obj/item/clothing/neck/old_neck = M.get_item_by_slot(SLOT_NECK)
+		if(old_neck)
+			qdel(old_neck)
+		var/obj/item/clothing/neck/roguetown/gorget/prisoner/servant = new(get_turf(M))
+		M.equip_to_slot_or_del(servant, SLOT_NECK, TRUE)
 		playsound(src.loc, 'sound/items/beartrap.ogg', 100, TRUE, -1)
-		M.wear_neck.forceMove(loc)
-		M.equip_to_slot_if_possible(newcollar, SLOT_NECK, FALSE, TRUE, TRUE, TRUE)
 	else
 		say("This skull carries no reward, you fool.")
 		playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)

--- a/code/modules/roguetown/roguemachine/grove.dm
+++ b/code/modules/roguetown/roguemachine/grove.dm
@@ -10,6 +10,10 @@
 	var/last_used = 0
 	var/cooldown_time = 300
 
+/obj/item/clothing/neck/roguetown/psicross/dendor/grove/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, "greater amulet of nature")
+
 /obj/item/clothing/neck/roguetown/psicross/dendor/grove/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	if(!proximity_flag)


### PR DESCRIPTION
## About The Pull Request

- Modifies the bounty collar making it clear this is an enchanted collar. Additionally, clarifies that anyone wearing the collar only has to take orders from citizens of the Town that do not result in self harm, forced sexual interactions, or orders that will indirectly/directly harm the town.
- Fixes it so anyone in the Grove can remove the collars and the bounties.
- Makes it properly equip
- Fixes a bug with the druid amulet
- Makes it so you can print an enchanted bounty scroll from the Excidium (for 50 mammon), constantly showing you an updated bounty list.

## Why It's Good For The Game

player feedback = good
