### PR TITLE
Grove Feedback Changes pt.2 

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -308,35 +308,48 @@
 	icon_state = "skinningknife"
 
 
-/obj/item/rogueweapon/woodstaff/thornlash
-	name = "thornlash staff"
-	desc = "A mystical wooden staff wrapped in thorny vines. The vines pulse with druidic energy, ready to inflict nature's judgment upon wrongdoers."
-	force = 5
-	force_wielded = 10
-	possible_item_intents = list(SPEAR_BASH)
-	gripped_intents = list(SPEAR_BASH, /datum/intent/mace/smash/wood)
-	wlength = WLENGTH_LONG
-	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = ITEM_SLOT_BACK
+/obj/item/rogueweapon/mace/cudgel/thornlash
+	name = "thornlash cudgel"
+	desc = "A runed cudgel wrapped in mystical thorny vines. The vines pulse with druidic energy, ready to subdue and restrain wrongdoers."
+	force = 10
+	force_wielded = 16
+	color = "#795548"
+	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash)
+	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash)
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_HIP
 	blade_dulling = DULLING_BASHCHOP
-	walking_stick = TRUE
-	max_integrity = 800
+	max_integrity = 1000
 	wdefense = 10
-	associated_skill = /datum/skill/combat/polearms
-	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg', 'sound/combat/wooshes/bladed/wooshsmall (2).ogg', 'sound/combat/wooshes/bladed/wooshsmall (3).ogg')
+	associated_skill = /datum/skill/combat/maces
 	sharpness = IS_BLUNT
 	var/cuffing = FALSE
 
-/obj/item/rogueweapon/woodstaff/thornlash/funny_attack_effects(mob/living/target, mob/living/user, nodmg)
+/obj/item/rogueweapon/mace/cudgel/thornlash/funny_attack_effects(mob/living/target, mob/living/user, nodmg)
 	. = ..()
 	if(!nodmg && isliving(target))
 		var/mob/living/L = target
-		var/stamina_damage = wielded ? 45 : 25
+		var/stamina_damage = wielded ? 65 : 45
 		L.rogfat_add(stamina_damage)
 
-		if(L.rogfat >= L.maxrogfat)
-			L.Paralyze(6 SECONDS)
-			to_chat(L, span_danger("The thorns sap my strength, making it impossible to move!"))
+		if(prob(25))
+			L.Knockdown(4 SECONDS)
+			to_chat(L, span_danger("The thorny cudgel sweeps my legs out from under me!"))
+			user.visible_message(span_warning("[user] sweeps [L]'s legs with the thornlash cudgel!"))
+
+		if(prob(25) && iscarbon(L))
+			var/mob/living/carbon/C = L
+			var/obj/item/I = C.get_active_held_item()
+			if(I)
+				C.dropItemToGround(I)
+				to_chat(C, span_danger("The thorny vines wrap around my wrist, forcing me to drop what I'm holding!"))
+				user.visible_message(span_green("[user]'s thornlash cudgel disarms [C]!"))
+
+		if(prob(25) && iscarbon(L))
+			var/mob/living/carbon/C = L
+			C.reagents.add_reagent(/datum/reagent/medicine/soporpot, 1)
+			to_chat(C, span_danger("The thorny vines inject something into my bloodstream!"))
+			user.visible_message(span_green("[user]'s thornlash cudgel injects a substance into [C]!"))
 
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
@@ -344,13 +357,13 @@
 				cuffing = TRUE
 				user.visible_message(span_green("[user] begins wrapping [C]'s wrists with vines!"))
 				to_chat(C, span_userdanger("[user] begins wrapping my wrists with vines!"))
-				if(do_after(user, 5 SECONDS, C))
+				if(do_after(user, 3 SECONDS, C))
 					if(C.handcuffed || (!C.IsParalyzed() && C.rogfat < C.maxrogfat))
 						cuffing = FALSE
 						return
 					var/obj/item/rope/vine_cuffs = new(C)
 					vine_cuffs.name = "thorny vine restraints"
-					vine_cuffs.desc = "Restraints made from druidically-enhanced thorny vines."
+					vine_cuffs.desc = "Restraints made from druidically-enhanced thorny vines. They seem particularly difficult to break free from."
 					vine_cuffs.color = "#0F3F0F"
 					C.handcuffed = vine_cuffs
 					C.update_handcuffed()
@@ -359,3 +372,93 @@
 					playsound(C, 'sound/foley/dropsound/cloth_drop.ogg', 30, TRUE)
 					SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 				cuffing = FALSE
+
+/obj/item/rogueweapon/whip/druidic
+	name = "druidic whip"
+	desc = "A mystical living whip that seems to writhe with primal energy. Three ancient runes pulse along its handle: one glows with toxic green, another with earthen brown, and the last with crimson vitality."
+	force = 15
+	force_wielded = 15
+	var/mode = 0 // 0 = normal, 1 = poison, 2 = draining, 3 = bleed
+	var/list/mode_names = list("dormant", "venomous", "draining", "thorned")
+	var/effect_message_cooldown = 0
+	var/list/slow_stacks = list()
+
+/obj/item/rogueweapon/whip/druidic/attack_self(mob/user)
+	mode = (mode + 1) % 4
+	var/effect_color
+	switch(mode)
+		if(0)
+			to_chat(user, span_green("The runes dim as the whip returns to its dormant form."))
+		if(1)
+			effect_color = "#4CAF50"
+			color = effect_color
+			to_chat(user, span_green("The poison rune flares to life with toxic energy!"))
+			var/obj/effect/temp_visual/dir_setting/rune_effect/RE = new(get_turf(user))
+			RE.color = effect_color
+		if(2)
+			effect_color = "#B39DDB"
+			color = effect_color
+			to_chat(user, span_green("The draining rune pulses with mystical power!"))
+			var/obj/effect/temp_visual/dir_setting/rune_effect/RE = new(get_turf(user))
+			RE.color = effect_color
+		if(3)
+			effect_color = "#EF5350"
+			color = effect_color
+			to_chat(user, span_green("The crimson rune blazes with thorned fury!"))
+			var/obj/effect/temp_visual/dir_setting/rune_effect/RE = new(get_turf(user))
+			RE.color = effect_color
+
+	playsound(user, 'sound/items/wood_sharpen.ogg', 50, TRUE)
+
+/obj/item/rogueweapon/whip/druidic/funny_attack_effects(mob/living/target, mob/living/user, nodmg)
+	. = ..()
+	if(!nodmg && isliving(target) && mode != 0)
+		var/mob/living/L = target
+		var/turf/T = get_turf(L)
+		var/effect_color
+		switch(mode)
+			if(1)
+				effect_color = "#4CAF50"
+				if(iscarbon(L))
+					var/mob/living/carbon/C = L
+					if(world.time > effect_message_cooldown)
+						user.visible_message(span_green("[user]'s whip exudes a toxic green mist as it strikes!"))
+						to_chat(C, span_green("Poisonous spores burst from the whip's strike, seeping into my wounds!"))
+						effect_message_cooldown = world.time + 10 SECONDS
+					C.reagents.add_reagent(/datum/reagent/toxin/berrypoison, 0.3)
+
+			if(2)
+				effect_color = "#B39DDB"
+				if(world.time > effect_message_cooldown)
+					user.visible_message(span_green("Magical vines sprout from [user]'s whip, reaching for [L]!"))
+					to_chat(L, span_green("Mystical vines wrap around my body, draining my energy!"))
+					if(iscarbon(L))
+						var/mob/living/carbon/C = L
+						if(C.rogstam > 50)
+							C.rogstam_add(-50)
+							if(iscarbon(user))
+								var/mob/living/carbon/U = user
+								U.rogstam_add(30)
+								to_chat(U, span_green("The vines transfer [L]'s energy to me!"))
+					effect_message_cooldown = world.time + 10 SECONDS
+
+			if(3)
+				effect_color = "#EF5350"
+				if(iscarbon(L))
+					var/mob/living/carbon/C = L
+					if(world.time > effect_message_cooldown)
+						user.visible_message(span_green("The whip's thorns grow and sharpen instantly as they tear into [L]!"))
+						to_chat(C, span_green("The whip's thorns pulse with primal energy as they rend my flesh!"))
+						effect_message_cooldown = world.time + 10 SECONDS
+					C.bleed(5)
+
+		if(T && effect_color)
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter(T, pick(GLOB.alldirs))
+			var/obj/effect/temp_visual/dir_setting/rune_effect/RE = new(T)
+			RE.color = effect_color
+
+/obj/effect/temp_visual/dir_setting/rune_effect
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "shield-flash"
+	duration = 6
+	layer = ABOVE_MOB_LAYER

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -243,6 +243,14 @@
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDEHAIR
 	dynamic_hair_suffix = ""
 
+/obj/item/clothing/head/roguetown/dendormask/greatdruid
+	name = "sylvarn's grace"
+	desc = "A mask made out of enchanted wood and infused energies, worn by Great Druids of timeless wisdom and fearful mastery of nature's will."
+	icon_state = "priesthead"
+	item_state = "priesthead"
+	flags_inv = HIDEFACIALHAIR|HIDEHAIR
+	dynamic_hair_suffix = ""
+
 /obj/item/clothing/head/roguetown/necromhood
 	name = "necromancers hood"
 	color = null
@@ -725,6 +733,13 @@
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	max_integrity = 400
+
+/obj/item/clothing/head/roguetown/helmet/elfbarbutewings/Hedgeguard
+	name = "hedgeguard's helm"
+	desc = "An ironwood helm in the style of the Hedge-Guard of the Breuddwyd Grove. It's adorned with ornate thorns and iconography, signifying devotion to Sylvarn."
+	icon_state = "dendorhelm"
+	item_state = "dendorhelm"
+	color = "#9a7a54"
 
 /obj/item/clothing/head/roguetown/helmet/heavy/guard
 	name = "savoyard"

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -72,7 +72,7 @@
 	l_sleeve_status = SLEEVE_NORMAL
 
 /obj/item/clothing/suit/roguetown/shirt/robe/dendor
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK|ITEM_SLOT_SHIRT
 	name = "briar robe"
 	desc = "Robes worn by Druid's in service to nature."
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|VITALS

--- a/code/modules/jobs/job_types/roguetown/breugrove/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/druid.dm
@@ -28,20 +28,34 @@
 	jobtype = /datum/job/roguetown/druid
 	allowed_patrons = list(/datum/patron/divine/sylvarn)
 
+/datum/job/roguetown/druid/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(istype(H.cloak, /obj/item/clothing/cloak/templar/dendor))
+			var/obj/item/clothing/S = H.cloak
+			var/index = findtext(H.real_name, " ")
+			if(index)
+				index = copytext(H.real_name, 1,index)
+			if(!index)
+				index = H.real_name
+			S.name = "Breuddwyd Grove Tabard ([index])"
+
 /datum/outfit/job/roguetown/druid/pre_equip(mob/living/carbon/human/H)
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/boots/forestershoes
 	pants = /obj/item/clothing/under/roguetown/loincloth/brown
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/rogueweapon/whip
+	beltl = /obj/item/rogueweapon/whip/druidic
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backr = /obj/item/rogueweapon/woodstaff/aries
-	head = /obj/item/clothing/head/roguetown/dendormask
+	backr = /obj/item/rogueweapon/woodstaff/wise
+	head = /obj/item/clothing/head/roguetown/antlerhood
 	neck = /obj/item/clothing/neck/roguetown/psicross/dendor/grove
-	gloves = null
-	cloak = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
+	gloves = /obj/item/clothing/gloves/roguetown/leather/advanced
+	cloak = /obj/item/clothing/cloak/templar/dendor
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
 	backpack_contents = list(
 		/obj/item/rogueweapon/sickle = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot = 1,
@@ -50,6 +64,7 @@
 		/obj/item/rogueweapon/huntingknife/skin = 1,
 	)
 	if(H.mind)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 3, TRUE)
 
@@ -86,6 +101,8 @@
 	ADD_TRAIT(H, TRAIT_VINE_WALKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_WILD_EATER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_KNEESTINGER_IMMUNITY, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_spells(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/breugrove/greatdruid.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/greatdruid.dm
@@ -29,20 +29,34 @@
 	jobtype = /datum/job/roguetown/greatdruid
 	allowed_patrons = list(/datum/patron/divine/sylvarn)
 
+/datum/job/roguetown/greatdruid/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(istype(H.cloak, /obj/item/clothing/cloak/templar/dendor))
+			var/obj/item/clothing/S = H.cloak
+			var/index = findtext(H.real_name, " ")
+			if(index)
+				index = copytext(H.real_name, 1,index)
+			if(!index)
+				index = H.real_name
+			S.name = "Breuddwyd Grove Tabard ([index])"
+
 /datum/outfit/job/roguetown/greatdruid/pre_equip(mob/living/carbon/human/H)
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/boots/forestershoes
-	cloak = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
+	cloak = /obj/item/clothing/cloak/templar/dendor
 	pants = /obj/item/clothing/under/roguetown/loincloth/brown
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/rogueweapon/whip
+	beltl = /obj/item/rogueweapon/whip/druidic
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backr = /obj/item/rogueweapon/woodstaff/aries
-	head = /obj/item/clothing/head/roguetown/antlerhood
+	backr = /obj/item/rogueweapon/woodstaff/wise
+	head = /obj/item/clothing/head/roguetown/dendormask/greatdruid
 	neck = /obj/item/clothing/neck/roguetown/psicross/dendor/grove
-	gloves = null
+	gloves = /obj/item/clothing/gloves/roguetown/leather/advanced
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
 	backpack_contents = list(
 		/obj/item/reagent_containers/glass/bottle/rogue/antipoisonpot = 2,
 		/obj/item/reagent_containers/glass/bottle/rogue/majorhealthpot = 2,
@@ -50,6 +64,7 @@
 		/obj/item/rogueweapon/huntingknife/skin = 1,
 	)
 	if(H.mind)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
 
@@ -86,6 +101,8 @@
 	ADD_TRAIT(H, TRAIT_VINE_WALKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_WILD_EATER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_KNEESTINGER_IMMUNITY, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_spells(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/breugrove/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/hedgeknight.dm
@@ -35,7 +35,7 @@
 
 /datum/outfit/job/roguetown/hedgeknight/pre_equip(mob/living/carbon/human/H)
 	. = ..()
-	head = /obj/item/clothing/head/roguetown/helmet/foresterhelmet
+	head = /obj/item/clothing/head/roguetown/helmet/elfbarbutewings/Hedgeguard
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/foresterarmor
 	cloak = /obj/item/clothing/cloak/templar/dendor
 	neck = /obj/item/clothing/neck/roguetown/psicross/dendor/grove
@@ -46,19 +46,19 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/forestershoes
 	beltl = /obj/item/quiver/arrows
 	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/rogueweapon/mace/cudgel/thornlash
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
-	l_hand = /obj/item/rogueweapon/woodstaff/thornlash
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1, /obj/item/signal_horn = 1, /obj/item/roguekey/grove = 1,)
 
 	if(H.mind)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 4, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 3, TRUE)
 
@@ -69,6 +69,8 @@
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/riding, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/labor/farming, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 1, TRUE)
 
 		H.change_stat("constitution", 4)
 		H.change_stat("perception", 3)
@@ -79,5 +81,8 @@
 	H.verbs |= /mob/proc/haltyell
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_VINE_WALKER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_KNEESTINGER_IMMUNITY, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_WILD_EATER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BLINDFIGHTING, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/breugrove/hedgewarden.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/hedgewarden.dm
@@ -46,21 +46,21 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/rogueweapon/mace/cudgel/thornlash
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/quiver/Parrows
-	l_hand = /obj/item/rogueweapon/woodstaff/thornlash
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1, /obj/item/roguekey/grove = 1)
 	if(H.mind)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 6, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/bows, 6, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/maces, 6, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/shields, 5, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 3, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
 
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 1, TRUE)
@@ -71,6 +71,9 @@
 
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/labor/farming, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 1, TRUE)
+
 		H.change_stat("constitution", 5)
 		H.change_stat("perception", 4)
 		H.change_stat("endurance", 5)
@@ -80,6 +83,8 @@
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_VINE_WALKER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BOG_TREKKING, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_SHOCKIMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_WILD_EATER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_KNEESTINGER_IMMUNITY, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BLINDFIGHTING, TRAIT_GENERIC)

--- a/code/modules/roguetown/roguemachine/grove.dm
+++ b/code/modules/roguetown/roguemachine/grove.dm
@@ -4,11 +4,40 @@
 
 /obj/item/clothing/neck/roguetown/psicross/dendor/grove
 	name = "greater amulet of nature"
-	desc = "An enhanced amulet of nature that allows its wielder to create mystical pathways through the trees. Click any tree while holding this amulet to create druidic waygates to various locations."
+	desc = "An enhanced amulet of nature that allows its wielder to create mystical pathways through the trees. Click any tree while holding this amulet to create druidic waygates to various locations. You can also activate it in your hand to send a distress signal."
 	icon_state = "dendor"
 	var/channeling = FALSE
 	var/last_used = 0
 	var/cooldown_time = 300
+	var/last_distress = 0
+	var/distress_cooldown = 300
+
+/obj/item/clothing/neck/roguetown/psicross/dendor/grove/attack_self(mob/user)
+	. = ..()
+	if(world.time < last_distress + distress_cooldown)
+		var/remaining_time = round((last_distress + distress_cooldown - world.time)/10)
+		to_chat(user, "<span class='warning'>The amulet's distress signal hasn't yet recovered. [remaining_time] seconds remaining.</span>")
+		return
+
+	var/choice = alert(user, "Do you wish to send a distress signal to the Grove?", "Nature's Distress", "Yes", "No")
+	if(choice != "Yes")
+		return
+
+	last_distress = world.time
+
+	var/area/A = get_area(user)
+	var/message = "<span class='boldannounce'>GROVEMEMBER'S DISTRESS: [user.name] seeks assistance in [A.name]! (<a href='?src=[REF(src)];alert_response=1;caller=[user.name]'>Create Waygate</a>)</span>"
+
+	for(var/mob/M in GLOB.player_list)
+		if(M.mind && (M.mind.assigned_role in list("Great Druid", "Druid", "Hedge Warden", "Hedge Knight")))
+			to_chat(M, message)
+			SEND_SOUND(M, sound('sound/misc/treefall.ogg'))
+
+	to_chat(user, "<span class='green'>You grasp the amulet tightly, sending ripples of natural energy outward...</span>")
+	playsound(src, 'sound/misc/treefall.ogg', 50, TRUE)
+
+	var/obj/effect/temp_visual/shrine_activation/effect = new(get_turf(src))
+	effect.color = "#4ca64c"
 
 /obj/item/clothing/neck/roguetown/psicross/dendor/grove/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
@@ -26,7 +55,8 @@
 		return
 
 	if(world.time < last_used + cooldown_time)
-		to_chat(user, "<span class='warning'>The amulet's power hasn't yet recovered. Please wait a moment.</span>")
+		var/remaining_time = round((last_used + cooldown_time - world.time)/10)
+		to_chat(user, "<span class='warning'>The amulet's power hasn't yet recovered. [remaining_time] seconds remaining.</span>")
 		return
 
 	if(channeling)
@@ -188,7 +218,8 @@
 		return
 
 	if(world.time < last_used + cooldown_time)
-		to_chat(user, "<span class='warning'>The shrine's energy hasn't yet recovered. Please wait a moment.</span>")
+		var/remaining_time = round((last_used + cooldown_time - world.time)/10)
+		to_chat(user, "<span class='warning'>The shrine's energy hasn't yet recovered. [remaining_time] seconds remaining.</span>")
 		return
 
 	var/choice = alert(user, "Do you wish to summon the Hedge Guard?", "Grove Shrine", "Yes", "No")
@@ -201,7 +232,8 @@
 
 	last_used = world.time
 
-	var/message = "<span class='boldannounce'>GROVE SHRINE ALERT: [user.name] seeks assistance! (<a href='?src=[REF(src)];alert_response=1;caller=[user.name]'>Create Waygate</a>)</span>"
+	var/area/A = get_area(user)
+	var/message = "<span class='boldannounce'>GROVE SHRINE ALERT: [user.name] seeks assistance in [A.name]! (<a href='?src=[REF(src)];alert_response=1;caller=[user.name]'>Create Waygate</a>)</span>"
 
 	for(var/mob/M in GLOB.player_list)
 		if(M.mind && (M.mind.assigned_role in list("Great Druid", "Druid", "Hedge Warden", "Hedge Knight")))
@@ -290,7 +322,8 @@
 		return
 
 	if(world.time < last_used + cooldown_time)
-		to_chat(user, "<span class='warning'>The speaking stone's energy hasn't yet recovered. Please wait a moment.</span>")
+		var/remaining_time = round((last_used + cooldown_time - world.time)/10)
+		to_chat(user, "<span class='warning'>The speaking stone's energy hasn't yet recovered. [remaining_time] seconds remaining.</span>")
 		return
 
 	var/message = stripped_input(user, "What message do you wish to convey to the town?", "Druidic Announcement", "")

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -482,7 +482,7 @@
 	H.devotion?.excommunicate()
 
 /datum/quirk/bounty
-	name = "Hunted Man"
+	name = "Hunted Man (NOT WANTED BY GROVE)"
 	desc = "Someone put a bounty on my head, whether for legitimate reasons or not. The local Adventurers' Guild might be able to protect me if I can make some friends there, but my life will always be in danger from those seeking to collect. (I can get attacked by other people for bounty as justification, for capture or death.)"
 	value = -3
 
@@ -522,14 +522,15 @@
 	to_chat(H, span_notice("Whether I done it or not, I have been accused of [reason], and a [employer] put a bounty on my head!"))
 
 /datum/quirk/outlaw
-	name = "Outlaw"
+	name = "Outlaw (WANTED BY GROVE)"
 	desc = "I'm on the wrong side of the law, I've managed to avoid capture so far but the law is coming for me, it's only a matter of time."
-	value = -2
+	value = -4
 
 /datum/quirk/outlaw/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.apply_status_effect(/datum/status_effect/grove_outlaw, "Wanted Fugitive")
 	make_outlaw(H.real_name, TRUE)
+	H.mind.special_items["Rag Mask"] = /obj/item/clothing/mask/rogue/ragmask
 
 /datum/quirk/sillyvoice
 	name = "Annoying"

--- a/modular_stonehedge/code/modules/mob/living/simple_animal/rogue/friendly_npc.dm
+++ b/modular_stonehedge/code/modules/mob/living/simple_animal/rogue/friendly_npc.dm
@@ -215,6 +215,14 @@
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
+
+		if((H.wear_mask && (H.wear_mask.flags_inv & HIDEFACE)) || (H.head && (H.head.flags_inv & HIDEFACE)))
+			return FALSE
+
+		if(H == lasthitter)
+			return TRUE
+
+		// Only check grove outlaw status if we can see their face
 		if(H.has_status_effect(/datum/status_effect/grove_outlaw))
 			if(!failed_arrests[H.real_name])
 				failed_arrests[H.real_name] = 0
@@ -563,7 +571,7 @@ GLOBAL_LIST_EMPTY_TYPED(patrol_points, /obj/effect/landmark/townpatrol)
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	pants = /obj/item/clothing/under/roguetown/chainlegs
-	head = /obj/item/clothing/head/roguetown/helmet/elfbarbutewings
+	head = /obj/item/clothing/head/roguetown/helmet/dendorhelm
 	if(prob(60))
 		mask = /obj/item/clothing/mask/rogue/facemask
 	gloves = /obj/item/clothing/gloves/roguetown/chain
@@ -611,7 +619,7 @@ GLOBAL_LIST_EMPTY_TYPED(patrol_points, /obj/effect/landmark/townpatrol)
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	pants = /obj/item/clothing/under/roguetown/chainlegs
-	head = /obj/item/clothing/head/roguetown/helmet/elfbarbutewings
+	head = /obj/item/clothing/head/roguetown/helmet/dendorhelm
 	if(prob(60))
 		mask = /obj/item/clothing/mask/rogue/facemask
 	gloves = /obj/item/clothing/gloves/roguetown/chain


### PR DESCRIPTION
everything has been tested, is functional, and compiles

## Changelog

- Makes it so the SmartNPCs won't target you for your mark if you have your face concealed.
- Raises quirk points received for taking Outlaw and gives them a rag mask (per Derrflamenwerfer)
- Clarifies the difference betwen marked man and outlaw
- Edits the loadout of Druid and Greatdruid based on player feedback (thanks suica for the outfit suggestion)
- Additional balance tweaking in anticipation of a full-scale balance PR (coming soon TM)
- Adds a special whip for Druids/Great Druids with three distinct modes
- Makes it so if you click inhand with the greater amulet of nature an option appears to send a distress signal to the grove.
- Changes the Thornlash Staff into a Thornlash Cudgel based on player feedback. Added additional functionality to mitigate the 95% dodge chance everyone has.
- Makes it so alerts from the shrine also show the area where the alert is coming from.
- Adds a new subtype mask for the great druid (future functionality incoming), and helm for the hedgeknights.
- Allows the Dendor Robe to be worn in the shirt slot.