### PR TITLE
Bug Fixes and Stuff pt. 1

### DIFF
--- a/code/datums/migrants/migrant_waves/slaver roles.dm
+++ b/code/datums/migrants/migrant_waves/slaver roles.dm
@@ -213,7 +213,7 @@
 /datum/outfit/job/roguetown/slaver/slavez/pre_equip(mob/living/carbon/human/H)
 	..()
 	armor = /obj/item/clothing/suit/roguetown/shirt/rags
-	neck = /obj/item/clothing/neck/roguetown/gorget/prisoner
+	neck = /obj/item/clothing/neck/roguetown/gorget/servant/imprisoned
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/storage/belt/rogue/pouch
 	beltr = /obj/item/flint

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -389,6 +389,7 @@
 	switch(mode)
 		if(0)
 			to_chat(user, span_green("The runes dim as the whip returns to its dormant form."))
+			color = null
 		if(1)
 			effect_color = "#4CAF50"
 			color = effect_color

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -243,14 +243,6 @@
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDEHAIR
 	dynamic_hair_suffix = ""
 
-/obj/item/clothing/head/roguetown/dendormask/greatdruid
-	name = "sylvarn's grace"
-	desc = "A mask made out of enchanted wood and infused energies, worn by Great Druids of timeless wisdom and fearful mastery of nature's will."
-	icon_state = "priesthead"
-	item_state = "priesthead"
-	flags_inv = HIDEFACIALHAIR|HIDEHAIR
-	dynamic_hair_suffix = ""
-
 /obj/item/clothing/head/roguetown/necromhood
 	name = "necromancers hood"
 	color = null
@@ -1270,6 +1262,10 @@
 	anvilrepair = null
 	sewrepair = TRUE
 	blocksound = SOFTHIT
+
+/obj/item/clothing/head/roguetown/helmet/leather/volfhelm/greatdruid
+	name = "sylvarn's pelt-covered helm"
+	desc = "A sacred helm passed between Great Druids, crafted from the pelt of one of Sylvarn's own familiars. The volf who provided this pelt was said to have lived for centuries protecting the four aspects of the Wyld Huntsman's seasons, before it was murdered by a group of adventurers for coin. It serves as a reminder that civilization is cruel, as are its people."
 
 /obj/item/clothing/head/roguetown/helmet/leather/bearhead
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_HIP

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -186,37 +186,33 @@
 	salvage_result = /obj/item/natural/hide/cured
 	clothing_flags = null
 
-/obj/item/clothing/neck/roguetown/gorget/prisoner/Initialize()
-	. = ..()
-	name = "cursed collar"
-	clothing_flags = null
+/obj/item/clothing/neck/roguetown/gorget/servant
+	name = "enchanted servant collar"
+	desc = "This collar makes me obligated to heed to orders from the citizens of the Town, and restricts my movements..."
 
-/obj/item/clothing/neck/roguetown/gorget/prisoner/servant/equipped(mob/living/carbon/human/user, slot)
+/obj/item/clothing/neck/roguetown/gorget/servant/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(!(src in user.held_items))
 		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/neck/roguetown/gorget/prisoner/canStrip(mob/living/carbon/human/stripper, mob/living/carbon/human/owner)
-	if(usr.job == "Great Druid" || usr.job == "Druid" || usr.job == "Hedge Warden" || usr.job == "Hedge Knight" || usr.job == "Ovate")
-		to_chat(usr, span_warning("I disable the collar's enchanted locking mechanism. It will only reactivate when worn again."))
+/obj/item/clothing/neck/roguetown/gorget/servant/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	if(slot == SLOT_NECK)
+		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+		ADD_TRAIT(user, TRAIT_PACIFISM, CURSED_ITEM_TRAIT)
+		user.visible_message(span_warning("[user] is bound by the collar's enchantment."), \
+			span_warning("This collar makes me heed to orders from the citizens of the Town, unless those orders will result in self harm, forced sexual interactions, or orders that will indirectly or directly harm the town or its population. It also restricts my movement."))
+		to_chat(user, span_alert("Roleplay accordingly to your collar's effects."))
+
+/obj/item/clothing/neck/roguetown/gorget/servant/canStrip(mob/living/carbon/human/stripper, mob/living/carbon/human/owner)
+	if(stripper.job == "Great Druid" || stripper.job == "Druid" || stripper.job == "Hedge Warden" || stripper.job == "Hedge Knight" || stripper.job == "Ovate")
+		to_chat(stripper, span_warning("I disable the collar's enchanted locking mechanism. It will only reactivate when worn again."))
 		REMOVE_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 		return TRUE
 	else
 		return ..()
 
-/obj/item/clothing/neck/roguetown/gorget/prisoner/servant
-	name = "enchanted bounty-collar"
-	desc = "This collar makes me obligated to heed to orders from the citizens of the Town, and restricts my movements..."
-
-/obj/item/clothing/neck/roguetown/gorget/prisoner/servant/equipped(mob/living/carbon/human/user, slot)
-	. = ..()
-	if(slot == SLOT_NECK)
-		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
-		ADD_TRAIT(user, TRAIT_PACIFISM, CURSED_ITEM_TRAIT)
-		to_chat(user, span_warning("This collar makes me heed to orders from the citizens of the Town, unless those orders will result in self harm, forced sexual interactions, or orders that will indirectly or directly harm the town or its population. It also restricts my movement."))
-		to_chat(user, span_alert("Roleplay accordingly to your collar's effects."))
-
-/obj/item/clothing/neck/roguetown/gorget/prisoner/dropped(mob/user)
+/obj/item/clothing/neck/roguetown/gorget/servant/dropped(mob/user)
 	. = ..()
 	if(!ishuman(user))
 		return
@@ -224,6 +220,20 @@
 	if(prisoner.get_item_by_slot(SLOT_NECK) != src)
 		REMOVE_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 		REMOVE_TRAIT(user, TRAIT_PACIFISM, CURSED_ITEM_TRAIT)
+
+
+/obj/item/clothing/neck/roguetown/gorget/servant/imprisoned
+	name = "enchanted prisoner collar"
+	desc = "This collar makes me obligated to heed to orders from anyone, and restricts my movements..."
+
+/obj/item/clothing/neck/roguetown/gorget/servant/imprisoned/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	if(slot == SLOT_NECK)
+		user.visible_message(span_warning("[user] is bound by the collar's enchantment."), \
+			span_warning("This collar makes me heed to orders from anyone, unless those orders will result in self harm or forced sexual interactions."))
+		to_chat(user, span_alert("Roleplay accordingly to your collar's effects."))
+
+
 
 /obj/item/clothing/neck/roguetown/psicross
 	name = "divine Symbol"

--- a/code/modules/jobs/job_types/roguetown/breugrove/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/druid.dm
@@ -19,8 +19,8 @@
 	tutorial = "You are a Druid of the Breuddwyd Grove, a sacred keeper of both natural and traditional law. Drawing power from the ancient spirits of the land, you maintain harmony between civilization and wilderness. As one of the Grove's spiritual authorities and Town's legal authorities, you interpret the wisdom written in both legal scrolls and forest leaves. Your judgments flow from the eternal laws of nature - as a stream shapes the stones, so too does justice shape society. While wielding primal magic and communing with beasts, your paramount duty is to preserve balance: mediating between town and wild, settling disputes through ancient rites, and ensuring both human law and nature's code are respected. Like the great oak that bridges earth and sky, you stand between the ordered realm of civilization and the raw power of the wilderness, drawing wisdom from both to maintain the sacred harmony."
 
 	display_order = JDO_DRUID
-	give_bank_account = FALSE
-	min_pq = 5
+	give_bank_account = 400
+	min_pq = 10
 	max_pq = null
 
 /datum/outfit/job/roguetown/druid

--- a/code/modules/jobs/job_types/roguetown/breugrove/greatdruid.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/greatdruid.dm
@@ -20,7 +20,7 @@
 
 	display_order = JDO_GREATDRUID
 	selection_color = JCOLOR_GROVE
-	give_bank_account = FALSE
+	give_bank_account = 800
 	min_pq = 15
 	max_pq = null
 
@@ -52,7 +52,7 @@
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/wise
-	head = /obj/item/clothing/head/roguetown/dendormask/greatdruid
+	head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm/greatdruid
 	neck = /obj/item/clothing/neck/roguetown/psicross/dendor/grove
 	gloves = /obj/item/clothing/gloves/roguetown/leather/advanced
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded

--- a/code/modules/jobs/job_types/roguetown/breugrove/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/hedgeknight.dm
@@ -15,7 +15,7 @@
 
 	outfit = /datum/outfit/job/roguetown/hedgeknight
 
-	give_bank_account = 1500
+	give_bank_account = 400
 	min_pq = 10
 	max_pq = null
 	cmode_music = 'sound/music/combat_bog.ogg'

--- a/code/modules/jobs/job_types/roguetown/breugrove/hedgewarden.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/hedgewarden.dm
@@ -15,7 +15,7 @@
 
 	outfit = /datum/outfit/job/roguetown/hedgewarden
 
-	give_bank_account = 2500
+	give_bank_account = 600
 	min_pq = 15
 	max_pq = null
 	cmode_music = 'sound/music/combat_bog.ogg'

--- a/code/modules/jobs/job_types/roguetown/breugrove/ovate.dm
+++ b/code/modules/jobs/job_types/roguetown/breugrove/ovate.dm
@@ -13,7 +13,7 @@
 	display_order = JDO_OVATE
 	selection_color = JCOLOR_GROVE
 	outfit = /datum/outfit/job/roguetown/ovate
-	give_bank_account = 30
+	give_bank_account = 200
 	min_pq = 0
 	max_pq = null
 

--- a/code/modules/jobs/job_types/roguetown/peasants/bogprisoner.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bogprisoner.dm
@@ -22,7 +22,7 @@
 
 /datum/outfit/job/roguetown/prisonerb/pre_equip(mob/living/carbon/human/H)
 	..()
-	neck = /obj/item/clothing/neck/roguetown/gorget/prisoner
+	neck = /obj/item/clothing/neck/roguetown/gorget/servant/imprisoned
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/lunatic.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/lunatic.dm
@@ -26,7 +26,7 @@
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/stealing, 2, TRUE)
 	ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
-	neck = /obj/item/clothing/neck/roguetown/gorget/prisoner/servant
+	neck = /obj/item/clothing/neck/roguetown/gorget/servant/imprisoned
 	if(H.gender == FEMALE)
 		pants = /obj/item/clothing/under/roguetown/tights/stockings
 	else
@@ -65,7 +65,7 @@
 	ADD_TRAIT(H, TRAIT_CRITICAL_WEAKNESS, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_ATHEISM_CURSE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_ENDOWMENT, TRAIT_GENERIC)
-	neck = /obj/item/clothing/neck/roguetown/gorget/prisoner
+	neck = /obj/item/clothing/neck/roguetown/gorget/servant/imprisoned
 	H.change_stat("strength", -20)
 	H.change_stat("intelligence", -20)
 	H.change_stat("constitution", -20)

--- a/code/modules/jobs/job_types/roguetown/peasants/prisoner.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/prisoner.dm
@@ -22,7 +22,7 @@
 
 /datum/outfit/job/roguetown/prisonerr/pre_equip(mob/living/carbon/human/H)
 	..()
-	neck = /obj/item/clothing/neck/roguetown/gorget/prisoner
+	neck = /obj/item/clothing/neck/roguetown/gorget/servant
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 1, TRUE)
@@ -47,4 +47,4 @@
 		pants = /obj/item/clothing/under/roguetown/tights/random
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
 		armor = /obj/item/clothing/suit/roguetown/shirt/tunic/random
-		
+

--- a/code/modules/jobs/job_types/roguetown/peasants/town slave.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/town slave.dm
@@ -21,7 +21,7 @@
 
 /datum/outfit/job/roguetown/prisonerd/pre_equip(mob/living/carbon/human/H)
 	..()
-	neck = /obj/item/clothing/neck/roguetown/gorget/prisoner/servant
+	neck = /obj/item/clothing/neck/roguetown/gorget/servant
 	if(H.gender == FEMALE)
 		pants = /obj/item/clothing/under/roguetown/tights/stockings
 	else

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -129,7 +129,7 @@
 		if(name in GLOB.outlawed_players)
 			. += span_userdanger("OUTLAW!")
 
-		if(istype(get_item_by_slot(SLOT_NECK), /obj/item/clothing/neck/roguetown/slavecollar)||istype(get_item_by_slot(SLOT_NECK), /obj/item/clothing/neck/roguetown/gorget/prisoner/servant))
+		if(istype(get_item_by_slot(SLOT_NECK), /obj/item/clothing/neck/roguetown/slavecollar)||istype(get_item_by_slot(SLOT_NECK), /obj/item/clothing/neck/roguetown/gorget/servant/imprisoned))
 			. += span_notice("It's a slave.")
 		if(mind)
 			var/mob/living/carbon/human/H = mind.current

--- a/code/modules/roguetown/roguemachine/academy.dm
+++ b/code/modules/roguetown/roguemachine/academy.dm
@@ -5,7 +5,7 @@
 //==============================================
 /obj/structure/wardingcrystal
 	name = "ravenloft warding crystal"
-	desc = "A crystal that shimmers with a warding glow, its surface veined with crackles of arcane energy, while faint, shadowy shapes swirl within, accompanied by an eerie hum and distant whispers."
+	desc = "A crystal that shimmers with a warding glow, its surface veined with crackles of arcane energy, while faint, shadowy shapes swirl within, accompanied by an eerie hum and distant whispers. For use when the Academy is facing a great danger."
 	icon = 'icons/obj/crystal.dmi'
 	icon_state = "Crystal"
 	anchored = TRUE
@@ -13,77 +13,138 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/active = FALSE
 	var/disabled_by_nullmagic = FALSE
+	var/total_active_time = 0
+	var/max_active_time = 10 MINUTES
+	var/needs_recharge = FALSE
+	var/last_active_time = 0
+	var/sublimate_charges = 0
 
-/obj/structure/wardingcrystal/attack_hand(mob/user)
-	to_chat(user, span_neutraltext("Whosoever doth seek to commune with the spirit bound within this crystal must first bear the Academy's Arch-Keystone in hand."))
-	return TRUE
+/obj/structure/wardingcrystal/Initialize()
+	. = ..()
+	START_PROCESSING(SSobj, src)
+	last_active_time = world.time
+
+/obj/structure/wardingcrystal/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/structure/wardingcrystal/process()
+	if(active && !needs_recharge)
+		var/time_since_last = world.time - last_active_time
+		total_active_time += time_since_last
+		last_active_time = world.time
+
+		if(total_active_time >= max_active_time)
+			needs_recharge = TRUE
+			active = FALSE
+			icon_state = "Crystal_Inert"
+			visible_message(span_redtext("[src]'s energies fade as it enters a depleted state!"))
+			playsound(src, 'sound/magic/churn.ogg', 50, TRUE)
+			for(var/obj/structure/academyward/ward in world)
+				if(!istype(ward, /obj/structure/academyward/perm))
+					ward.density = FALSE
+					ward.alpha = 0
+					ward.invisibility = INVISIBILITY_MAXIMUM
+
+/obj/structure/wardingcrystal/examine(mob/user)
+	. = ..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.job == "Academy Archmage" || H.job == "Academy Mage" || H.job == "Academy Apprentice")
+			if(needs_recharge)
+				. += span_redtext("The crystal's energies are depleted and requires [10 - sublimate_charges] more arcyne sublimate to recharge.")
+			else
+				var/time_left = max_active_time - total_active_time
+				. += span_notice("The crystal has enough arcyne sublimate for [round(time_left/600, 0.1)] minutes.")
 
 /obj/structure/wardingcrystal/attackby(obj/item/I, mob/user, params)
-    . = ..()
+	. = ..()
 
-    if(istype(I, /obj/item/clothing/ring/keystone/archkey))
-        var/obj/item/clothing/ring/keystone/archkey/key = I
-        if(!key.active)
-            to_chat(user, span_warning("The Archkeystone must first be activated. (Right-click to activate)"))
-            return
+	if(needs_recharge && istype(I, /obj/item/reagent_containers/powder/sublimate))
+		to_chat(user, span_notice("You begin feeding arcyne sublimate into the crystal's matrix..."))
+		if(do_after(user, 5 SECONDS, target = src))
+			sublimate_charges++
+			if(sublimate_charges >= 10)
+				sublimate_charges = 0
+				total_active_time = 0
+				needs_recharge = FALSE
+				icon_state = "Crystal"
+				playsound(src, 'sound/magic/churn.ogg', 50, TRUE)
+				visible_message(span_blue("[src] pulses with renewed energy as it absorbs the final sublimate!"))
+			else
+				visible_message(span_notice("[src] absorbs the sublimate. [10 - sublimate_charges] more needed for full recharge."))
+			qdel(I)
+		return TRUE
 
-        if(disabled_by_nullmagic)
-            audible_message(span_neutraltext("[user] begins channeling magical energy into the crystal..."), 7)
-            if(do_after(user, 10 SECONDS, target = src))
-                disabled_by_nullmagic = FALSE
-                audible_message(span_hear("The crystal rings out with a clear, harmonious tone as its power returns!"), 7)
-                for(var/mob/living/L in range(5, src))
-                    to_chat(L, span_blue("The crystal pulses with renewed vigor as arcane energy flows through it, its veins of power rekindling with brilliant light as ancient magicks stir once more within."), 7)
-                icon_state = "Crystal"
-                playsound(src, 'sound/magic/churn.ogg', 50, TRUE)
-                for(var/obj/structure/academyward/ward in world)
-                    if(!istype(ward, /obj/structure/academyward/perm))
-                        ward.density = active
-                        ward.alpha = active ? 125 : 0
-                        ward.invisibility = active ? null : INVISIBILITY_MAXIMUM
-                return TRUE
-            return
+	if(istype(I, /obj/item/clothing/ring/keystone/archkey))
+		var/obj/item/clothing/ring/keystone/archkey/key = I
+		if(!key.active)
+			to_chat(user, span_warning("The Arch-Keystone must first be activated. (Right-click to activate)"))
+			return
 
-        audible_message(span_neutraltext("[user] begins channeling energy through the keystone..."), 7)
-        if(do_after(user, 3 SECONDS, target = src))
-            active = !active
-            for(var/obj/structure/academyward/ward in world)
-                if(!istype(ward, /obj/structure/academyward/perm))
-                    ward.density = active
-                    ward.alpha = active ? 125 : 0
-                    ward.invisibility = active ? null : INVISIBILITY_MAXIMUM
+		if(disabled_by_nullmagic)
+			audible_message(span_neutraltext("[user] begins channeling magical energy into the crystal..."), 7)
+			if(do_after(user, 10 SECONDS, target = src))
+				disabled_by_nullmagic = FALSE
+				audible_message(span_hear("The crystal rings out with a clear, harmonious tone as its power returns!"), 7)
+				for(var/mob/living/L in range(5, src))
+					to_chat(L, span_blue("The crystal pulses with renewed vigor as arcane energy flows through it, its veins of power rekindling with brilliant light as ancient magicks stir once more within."), 7)
+				icon_state = "Crystal"
+				playsound(src, 'sound/magic/churn.ogg', 50, TRUE)
+				for(var/obj/structure/academyward/ward in world)
+					if(!istype(ward, /obj/structure/academyward/perm))
+						ward.density = active
+						ward.alpha = active ? 125 : 0
+						ward.invisibility = active ? null : INVISIBILITY_MAXIMUM
+				return TRUE
+			return
 
-            if(active)
-                audible_message(span_blue("A chorus of ethereal chimes echoes through the air as the academy's wards spring to life!"), 7)
-            else
-                audible_message(span_blue("The magical harmonies fade to silence as the academy's wards dissipate."), 7)
-            return TRUE
-        return
+		if(needs_recharge)
+			to_chat(user, span_warning("The crystal's energies are depleted and requires arcyne sublimate to recharge."))
+			return
 
-    if(disabled_by_nullmagic)
-        to_chat(user, span_warning("The crystal remains dark and unresponsive. An Archmage's power might be able to reinvigorate it..."))
-        return
+		audible_message(span_neutraltext("[user] begins channeling energy through the keystone..."), 7)
+		if(do_after(user, 3 SECONDS, target = src))
+			active = !active
+			if(active)
+				last_active_time = world.time
+			for(var/obj/structure/academyward/ward in world)
+				if(!istype(ward, /obj/structure/academyward/perm))
+					ward.density = active
+					ward.alpha = active ? 125 : 0
+					ward.invisibility = active ? null : INVISIBILITY_MAXIMUM
 
-    if(istype(I, /obj/item/clothing/ring/active/nomag))
-        var/obj/item/clothing/ring/active/nomag/ring = I
-        if(!ring.active)
-            to_chat(user, span_warning("The ring must first be activated. (Right-click to activate)"))
-            return
+			if(active)
+				audible_message(span_blue("A chorus of ethereal chimes echoes through the air as the academy's wards spring to life!"), 7)
+			else
+				audible_message(span_blue("The magical harmonies fade to silence as the academy's wards dissipate."), 7)
+			return TRUE
+		return
 
-        audible_message(span_cultlarge("[user] begins channeling null magic into the crystal..."), 7)
-        if(do_after(user, 5 SECONDS, target = src))
-            disabled_by_nullmagic = TRUE
-            icon_state = "Crystal_Inert"
-            audible_message(span_cultlarge("The crystal shudders violently as its arcane energies are disrupted, its inner light dimming to a dull, lifeless shade."), 7)
-            playsound(src, 'sound/magic/antimagic.ogg', 50, TRUE)
-            for(var/obj/structure/academyward/ward in world)
-                if(!istype(ward, /obj/structure/academyward/perm))
-                    ward.density = FALSE
-                    ward.alpha = 0
-                    ward.invisibility = INVISIBILITY_MAXIMUM
-        return TRUE
+	if(disabled_by_nullmagic)
+		to_chat(user, span_warning("The crystal remains dark and unresponsive. An Archmage's power might be able to reinvigorate it..."))
+		return
 
-    return ..()
+	if(istype(I, /obj/item/clothing/ring/active/nomag))
+		var/obj/item/clothing/ring/active/nomag/ring = I
+		if(!ring.active)
+			to_chat(user, span_warning("The ring must first be activated. (Right-click to activate)"))
+			return
+
+		audible_message(span_cultlarge("[user] begins channeling null magic into the crystal..."), 7)
+		if(do_after(user, 5 SECONDS, target = src))
+			disabled_by_nullmagic = TRUE
+			icon_state = "Crystal_Inert"
+			audible_message(span_cultlarge("The crystal shudders violently as its arcane energies are disrupted, its inner light dimming to a dull, lifeless shade."), 7)
+			playsound(src, 'sound/magic/antimagic.ogg', 50, TRUE)
+			for(var/obj/structure/academyward/ward in world)
+				if(!istype(ward, /obj/structure/academyward/perm))
+					ward.density = FALSE
+					ward.alpha = 0
+					ward.invisibility = INVISIBILITY_MAXIMUM
+		return TRUE
+
+	return ..()
 
 //==============================================
 //	Defensive Wards

--- a/code/modules/roguetown/roguemachine/bounty.dm
+++ b/code/modules/roguetown/roguemachine/bounty.dm
@@ -342,13 +342,6 @@
 					to_chat(grove_member, span_green("<b>Grove Judgment Alert:</b> [M.real_name] has been judged and sentenced by the POENA."))
 					playsound(grove_member, 'sound/misc/treefall.ogg', 50, TRUE)
 
-			if(M in SStreasury.bank_accounts)
-				var/money_to_take = round(SStreasury.bank_accounts[M] * 0.5)
-				if(money_to_take > 0)
-					SStreasury.bank_accounts[M] -= money_to_take
-					budget2change(money_to_take)
-					say("Extracting [money_to_take] mammons as penance.")
-
 		var/obj/item/clothing/neck/old_neck = M.get_item_by_slot(SLOT_NECK)
 		if(old_neck)
 			M.dropItemToGround(old_neck, TRUE)

--- a/code/modules/roguetown/roguemachine/bounty.dm
+++ b/code/modules/roguetown/roguemachine/bounty.dm
@@ -1,5 +1,5 @@
 /obj/structure/roguemachine/bounty
-	name = "Excidium"
+	name = "EXCIDIUM"
 	desc = "A machine that sets and collects bounties. Its bloodied maw could easily fit a human head."
 	icon = 'icons/roguetown/topadd/statue1.dmi'
 	icon_state = "baldguy"
@@ -270,8 +270,8 @@
 	info = scroll_text
 
 /obj/structure/chair/arrestchair
-	name = "BOUNTYMASTER"
-	desc = "A chairesque machine that collects bounties through enslavement to the Town rather than death, for a much greater reward."
+	name = "POENA"
+	desc = "A chairesque machine that clears grove marks and collects bounties, for a greater reward, through enslavement to the Town rather than death."
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "brass_chair"
 	blade_dulling = DULLING_BASH
@@ -291,20 +291,24 @@
 	M.Paralyze(3 SECONDS)
 
 	var/correct_head = FALSE
-
+	var/grove_marked = FALSE
 	var/reward_amount = 0
+
 	for(var/datum/bounty/b in GLOB.head_bounties)
 		if(b.target == M.real_name)
 			correct_head = TRUE
 			reward_amount += b.amount
 			GLOB.head_bounties -= b
 
+	if(M.has_status_effect(/datum/status_effect/grove_outlaw))
+		grove_marked = TRUE
+
 	say(pick(list("Performing intra-cranial inspection...", "Analyzing skull structure...", "Commencing cephalic dissection...")))
 
 	sleep(1 SECONDS)
 
 	if(M.stat == DEAD)
-		say("Yamais' hands are over this one, use the excidium.")
+		say("Yamais' hands are over this one, send them to the EXCIDIUM.")
 		playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 		unbuckle_all_mobs()
 		return
@@ -320,13 +324,35 @@
 
 	sleep(2 SECONDS)
 
-	if(correct_head)
-		say("A bounty has been sated.")
-		budget2change((reward_amount*2))
+	if(correct_head || grove_marked)
+		if(correct_head)
+			say("A bounty has been sated.")
+			budget2change((reward_amount*2))
+
+		if(grove_marked)
+			say("Nature's mark detected. Issuing summary judgment and commencing sentencing...")
+			M.remove_status_effect(/datum/status_effect/grove_outlaw)
+
+			for(var/obj/structure/grove_wanted/totem in world)
+				totem.marked_individuals -= M.real_name
+				totem.roundstart_marks -= M.real_name
+
+			for(var/mob/living/carbon/human/grove_member in GLOB.player_list)
+				if(grove_member.job in list("Great Druid", "Druid", "Hedge Warden", "Hedge Knight"))
+					to_chat(grove_member, span_green("<b>Grove Judgment Alert:</b> [M.real_name] has been judged and sentenced by the POENA."))
+					playsound(grove_member, 'sound/misc/treefall.ogg', 50, TRUE)
+
+			if(M in SStreasury.bank_accounts)
+				var/money_to_take = round(SStreasury.bank_accounts[M] * 0.5)
+				if(money_to_take > 0)
+					SStreasury.bank_accounts[M] -= money_to_take
+					budget2change(money_to_take)
+					say("Extracting [money_to_take] mammons as penance.")
+
 		var/obj/item/clothing/neck/old_neck = M.get_item_by_slot(SLOT_NECK)
 		if(old_neck)
-			qdel(old_neck)
-		var/obj/item/clothing/neck/roguetown/gorget/prisoner/servant = new(get_turf(M))
+			M.dropItemToGround(old_neck, TRUE)
+		var/obj/item/clothing/neck/roguetown/gorget/servant/servant = new(get_turf(M))
 		M.equip_to_slot_or_del(servant, SLOT_NECK, TRUE)
 		playsound(src.loc, 'sound/items/beartrap.ogg', 100, TRUE, -1)
 	else
@@ -334,12 +360,9 @@
 		playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 	M.Unconscious(15 SECONDS)
 
-
-	// Head has been "analyzed". Return it.
 	sleep(2 SECONDS)
 	playsound(src, 'sound/combat/vite.ogg', 100, FALSE, -1)
 	unbuckle_all_mobs()
-
 
 /obj/structure/chair/arrestchair/proc/budget2change(budget, mob/user, specify)
 	var/turf/T


### PR DESCRIPTION
final round of stuff i'm gonna do before i start the great job purge and balance change. it will be painstaking, there will be tears, but it is necessary. everything has been tested and compiles

## Changelog

- Raises druid PQ to match the Hedge Knight.
- Fixes the druidic whip not returning to a default color state when mode 0 is triggered
- Fixes the amulet's distress function. It will now properly create a waygate to the distress call.
- Did some backend stuff for emergency waygates for future implementation if needed.
- Fixes the bug that excluded roundstart marked from being displayed on the totem and prevented pardoning.
- Makes it so the BOUNTYMASTER (now POENA to match the EXCIDIUM's name) removes Grove Mark upon the application of a collar, and will trigger even if there is no bounty only a mark. 
- Cleans up the messy servant collar code
- Adds a bank account for every job in the Grove. (200 ovate; 400 druid/hedgeknight; 600 hedgewarden; 800 great druid)
- Replaces the temporary Great Druid helmet with the intended Great Druid helmet.
- Nerfs the Academy Barrier. It can now only stay active for a combined total of 10 minutes before requiring recharging. It needs 10 arcyne sublimate before it can be activated again. It's for emergencies, not to block all RP with everyone in the town.
