### PR TITLE
Torsion magic for Archmages

### DIFF
--- a/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
+++ b/code/modules/jobs/job_types/roguetown/academy/acadarchmage.dm
@@ -12,6 +12,7 @@
 	spells = list (
 		/obj/effect/proc_holder/spell/invoked/projectile/fireball/greater,
 		/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt,
+		/obj/effect/proc_holder/spell/invoked/torsion/arcane,
 		/obj/effect/proc_holder/spell/aoe_turf/conjure/Wolf,
 		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
 		/obj/effect/proc_holder/spell/targeted/touch/prestidigitation,


### PR DESCRIPTION
## About The Pull Request

Gives Academy Archmages the arcane version of the torsion spell, to torture intruding shitters with.

## Why It's Good For The Game

Doesn't _really_ add to combat capability because they have loads of magic already. Does nothing in PvE content, and you'd have to be ballsy (ha, ha, ha) to fight Archmages in PvP, in which case they'd rather annihilate you with lightning bolt instead of this gag spell. Shockproof doesn't exist on any normal class anymore (I think) so this is just worse than that - and half the time they get a chill grasp scroll from the academy bookshelves or something which makes this even more redundant mechanically.

Primarily serves as an additional way for a high-trust role to temporarily punish players behaving poorly. And because Archmage is a high-trust role, it's reasonable to levy higher penalties for being a shitter _with_ the spell to random people. Should be treated by admins as the same as a random fireball to the face.

Also it's funny.

If Spess thinks having the spell would detract from the Academy's RP environment I'd be fine just closing this, though it's worth noting that the callout is much more serious than the divine version. No asking Eora to twist their nuts, we love casting spells ourselves instead of calling on someone else.