### PR TITLE
Tailor's rebirth + Tavern tiny edits

### DIFF
--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -2934,7 +2934,7 @@
 	})
 "cbX" = (
 /obj/structure/table/wood{
-	dir = 6;
+	dir = 10;
 	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
@@ -6299,16 +6299,14 @@
 	first_time_text = "Ravenloft Academy";
 	name = "Ravenloft Academy"
 	})
-"enj" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "ens" = (
 /obj/effect/wisp,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/river)
+"enz" = (
+/obj/effect/landmark/start/tailor,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "enK" = (
 /obj/structure/flora/grass/jungle{
 	icon_state = "grassa2"
@@ -10169,13 +10167,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves)
-"gXc" = (
-/obj/effect/decal/border{
-	dir = 9
-	},
-/obj/effect/landmark/start/tailor,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "gXv" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -10546,6 +10537,12 @@
 /area/rogue/outdoors/woods{
 	first_time_text = "The Mountain Passe"
 	})
+"hji" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "hjY" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/natural/saddle,
@@ -13421,10 +13418,11 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/caves)
 "jiz" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "jiG" = (
 /obj/structure/chair/wood{
@@ -14431,10 +14429,6 @@
 	first_time_text = "The Sylver Dragonne..";
 	name = "Silver Dragon"
 	})
-"jOS" = (
-/obj/effect/landmark/start/tailor,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town)
 "jPn" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -14677,10 +14671,6 @@
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
 	})
-"jWK" = (
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "jWO" = (
 /obj/structure/closet/crate/chest/steward/blacksmith,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
@@ -15264,10 +15254,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves)
-"koo" = (
-/obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "koq" = (
 /obj/structure/crabnest,
 /turf/open/water/cleanshallow,
@@ -15623,6 +15609,12 @@
 /obj/effect/mist,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/caves)
+"kBO" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "kBW" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
@@ -17842,10 +17834,6 @@
 	first_time_text = "Shrine of Lune";
 	name = "Shrine of Lune"
 	})
-"mhy" = (
-/obj/structure/grove_shrine,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "mhU" = (
 /obj/structure/flora/newtree,
 /turf/open/water/river{
@@ -19109,11 +19097,9 @@
 	name = "Schoolgrounds"
 	})
 "mSm" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
-	},
-/turf/closed/wall/mineral/rogue/stone/moss,
-/area/rogue/indoors/town/bath)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "mSo" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/wisp,
@@ -19134,6 +19120,10 @@
 /area/rogue/outdoors/woods{
 	first_time_text = "The Twilight Woods"
 	})
+"mSI" = (
+/obj/structure/fermenting_barrel/random/wine,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "mSL" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 32
@@ -22397,13 +22387,6 @@
 	icon_state = "road"
 	},
 /area/rogue/indoors/shelter/bog)
-"peF" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
 "peQ" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/chair/wood/rogue/throne,
@@ -24893,6 +24876,9 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
+/obj/machinery/light/rogue/torchholder{
+	dir = 1
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "qFw" = (
@@ -25510,10 +25496,6 @@
 /area/rogue/indoors/town/bath{
 	first_time_text = "The Dreamers Demesne.."
 	})
-"qWz" = (
-/obj/effect/landmark/start/tailor,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "qWQ" = (
 /obj/structure/glowshroom,
 /turf/open/water/cleanshallow,
@@ -27397,6 +27379,10 @@
 /area/rogue/outdoors/woods{
 	first_time_text = "The Twilight Woods"
 	})
+"smo" = (
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "smT" = (
 /obj/structure/flora/roguetree/evil{
 	icon_state = "t5"
@@ -27940,9 +27926,12 @@
 /turf/open/floor/rogue/blocks/stone/stonepattern3,
 /area/rogue/under/cavewet)
 "sHV" = (
-/obj/structure/fermenting_barrel/random/beer/wine,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/tavern)
+/obj/effect/decal/border{
+	dir = 9
+	},
+/obj/effect/landmark/start/tailor,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "sIo" = (
 /obj/structure/spacevine/dendor,
 /turf/open/floor/rogue/grass,
@@ -28101,6 +28090,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods/grove)
+"sNl" = (
+/obj/structure/grove_shrine,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "sNr" = (
 /obj/structure/flora/newbranch/connector{
 	dir = 9;
@@ -28565,10 +28558,6 @@
 	first_time_text = "Emerald Shores";
 	name = "Shores of the Emerald Coast"
 	})
-"tem" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town)
 "teC" = (
 /obj/effect/decal/dirt{
 	dir = 8
@@ -33186,6 +33175,10 @@
 /obj/structure/flora/roguegrass/maneater/real,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/caves)
+"wnd" = (
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "wnj" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/rogue/dirt,
@@ -34021,6 +34014,10 @@
 /obj/structure/closet/crate/chest/dungeon/mimic,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
+"wTP" = (
+/obj/effect/landmark/start/tailor,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
 "wUa" = (
 /obj/structure/spacevine/dendor,
 /turf/open/floor/rogue/blocks/stone/stonepattern3,
@@ -34107,6 +34104,13 @@
 /obj/item/natural/rock/iron,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
+"wWD" = (
+/obj/structure/fermenting_barrel,
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/tavern)
 "wWK" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/rogue/blocks/stone/stonepattern3,
@@ -35438,6 +35442,9 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
+/obj/machinery/light/rogue/torchholder{
+	pixel_y = 26
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "xOB" = (
@@ -125880,7 +125887,7 @@ wZG
 iiU
 hAj
 tGs
-dav
+wWD
 tGs
 aJT
 iiU
@@ -126688,7 +126695,7 @@ oCe
 iiU
 oVR
 tGs
-sHV
+mSI
 tGs
 sOO
 evw
@@ -126887,13 +126894,13 @@ ucG
 auy
 oCe
 oCe
-loh
+iiU
 xOg
 tGs
 kgY
 tGs
 qFt
-mSm
+evw
 nJH
 seg
 rSY
@@ -136002,7 +136009,7 @@ tpS
 utn
 lnb
 lqk
-jWK
+wnd
 ueB
 cte
 rDz
@@ -136210,7 +136217,7 @@ cte
 ifd
 ubI
 dIC
-qWz
+enz
 xsa
 nhz
 kqj
@@ -137217,7 +137224,7 @@ hRw
 otT
 nqn
 bSd
-jOS
+wTP
 drT
 nqn
 dqQ
@@ -170543,8 +170550,8 @@ qoQ
 sLq
 bEj
 hRw
-koo
-enj
+smo
+hji
 dhw
 wxO
 uRl
@@ -171157,7 +171164,7 @@ bEj
 bEj
 quv
 oan
-gXc
+sHV
 bEj
 bEj
 mEa
@@ -171355,8 +171362,8 @@ oan
 dFV
 bEj
 bEj
-tem
-peF
+mSm
+cbX
 hRw
 ufU
 lFi
@@ -171554,11 +171561,11 @@ hxO
 iaH
 nkE
 bEj
-mhy
+sNl
 hRw
 hhT
-tem
-cbX
+mSm
+jiz
 hRw
 hRw
 hRw
@@ -171760,7 +171767,7 @@ hRw
 hRw
 hRw
 nwi
-jiz
+kBO
 hRw
 gTu
 bcc
@@ -172163,7 +172170,7 @@ hRw
 hRw
 hRw
 hRw
-koo
+smo
 bEj
 hRw
 gTu

--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -1330,7 +1330,7 @@
 "aTb" = (
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern{
@@ -2933,12 +2933,11 @@
 	name = "Schoolgrounds"
 	})
 "cbX" = (
-/obj/structure/mineral_door/wood{
-	name = "Farmer's Bedroom";
-	lockid = "farm";
-	locked = 1
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "ccn" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6300,6 +6299,12 @@
 	first_time_text = "Ravenloft Academy";
 	name = "Ravenloft Academy"
 	})
+"enj" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "ens" = (
 /obj/effect/wisp,
 /turf/open/floor/rogue/grass,
@@ -8988,6 +8993,10 @@
 /obj/effect/decal/border/ruinedwood{
 	dir = 4
 	},
+/obj/structure/roguemachine/withdraw{
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "fYD" = (
@@ -10160,6 +10169,13 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves)
+"gXc" = (
+/obj/effect/decal/border{
+	dir = 9
+	},
+/obj/effect/landmark/start/tailor,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "gXv" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -12578,7 +12594,8 @@
 "iCE" = (
 /obj/structure/mineral_door/wood/window{
 	name = "Tailor";
-	locked = 1
+	locked = 1;
+	lockid = "tailor"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -12949,8 +12966,8 @@
 	})
 "iRA" = (
 /obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+	icon_state = "largetable";
+	dir = 12
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13404,11 +13421,10 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/caves)
 "jiz" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
-	name = "Tailor"
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "jiG" = (
 /obj/structure/chair/wood{
@@ -13441,6 +13457,8 @@
 	})
 "jkg" = (
 /obj/machinery/light/rogue/oven/south,
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "jkv" = (
@@ -14192,10 +14210,7 @@
 	first_time_text = "The Twilight Woods"
 	})
 "jIX" = (
-/obj/structure/mineral_door/wood/window{
-	name = "Tailor";
-	locked = 1
-	},
+/turf/open/dark_filler,
 /area/rogue/outdoors/river)
 "jJk" = (
 /turf/open/floor/rogue/rooftop/green{
@@ -14416,6 +14431,10 @@
 	first_time_text = "The Sylver Dragonne..";
 	name = "Silver Dragon"
 	})
+"jOS" = (
+/obj/effect/landmark/start/tailor,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
 "jPn" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -14658,6 +14677,10 @@
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
 	})
+"jWK" = (
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "jWO" = (
 /obj/structure/closet/crate/chest/steward/blacksmith,
 /turf/open/floor/rogue/blocks/stone/stonepattern2,
@@ -14668,7 +14691,7 @@
 "jXh" = (
 /obj/structure/mineral_door/wood/window{
 	name = "Tailor";
-	locked = 1
+	lockid = "tailor"
 	},
 /turf/open/floor/rogue/twig{
 	dir = 4
@@ -15241,6 +15264,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves)
+"koo" = (
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "koq" = (
 /obj/structure/crabnest,
 /turf/open/water/cleanshallow,
@@ -15645,8 +15672,9 @@
 	dir = 4
 	},
 /obj/structure/mineral_door/wood/window{
-	name = "Tailor";
-	locked = 1
+	name = "Tailor's Quarters";
+	locked = 1;
+	lockid = "tailor"
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
@@ -16343,7 +16371,10 @@
 	name = "far stonehedge"
 	})
 "lau" = (
-/obj/structure/roguemachine/withdraw,
+/obj/structure/roguemachine/withdraw{
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/outdoors/beach{
 	first_time_text = "Emerald Shores";
@@ -16707,6 +16738,9 @@
 "lnb" = (
 /obj/effect/decal/border/ruinedwood/inverted{
 	dir = 1
+	},
+/obj/effect/landmark/start/villager{
+	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -17808,6 +17842,10 @@
 	first_time_text = "Shrine of Lune";
 	name = "Shrine of Lune"
 	})
+"mhy" = (
+/obj/structure/grove_shrine,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "mhU" = (
 /obj/structure/flora/newtree,
 /turf/open/water/river{
@@ -19505,9 +19543,9 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/caves)
 "nkE" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
-	name = "Tailor"
+/obj/structure/mineral_door/wood/window{
+	name = "Toilet";
+	lockid = "tailor"
 	},
 /turf/open/floor/rogue/blocks/stone/stonepattern3,
 /area/rogue/indoors/town)
@@ -21664,7 +21702,10 @@
 	name = "far stonehedge"
 	})
 "oHi" = (
-/obj/structure/roguemachine/withdraw,
+/obj/structure/roguemachine/withdraw{
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern{
 	first_time_text = "The Sylver Dragonne..";
@@ -22356,6 +22397,13 @@
 	icon_state = "road"
 	},
 /area/rogue/indoors/shelter/bog)
+"peF" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "peQ" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/chair/wood/rogue/throne,
@@ -22581,6 +22629,9 @@
 /area/rogue/under/cavewet/bogcaves)
 "plj" = (
 /obj/effect/decal/border/ruinedwood/inverted{
+	dir = 8
+	},
+/obj/effect/landmark/start/villager{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -24505,8 +24556,10 @@
 	name = "far stonehedge"
 	})
 "quv" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	name = "Tailor"
+/obj/structure/mineral_door/wood/window{
+	name = "Tailor's Quarters";
+	locked = 1;
+	lockid = "tailor"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -25457,6 +25510,10 @@
 /area/rogue/indoors/town/bath{
 	first_time_text = "The Dreamers Demesne.."
 	})
+"qWz" = (
+/obj/effect/landmark/start/tailor,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "qWQ" = (
 /obj/structure/glowshroom,
 /turf/open/water/cleanshallow,
@@ -25913,7 +25970,6 @@
 	},
 /area/rogue)
 "rlW" = (
-/obj/structure/roguemachine/withdraw,
 /obj/effect/decal/stone/chess{
 	dir = 8
 	},
@@ -28509,6 +28565,10 @@
 	first_time_text = "Emerald Shores";
 	name = "Shores of the Emerald Coast"
 	})
+"tem" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/carpet,
+/area/rogue/indoors/town)
 "teC" = (
 /obj/effect/decal/dirt{
 	dir = 8
@@ -30368,7 +30428,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern{
@@ -33387,6 +33447,15 @@
 	icon_state = "longtable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -6;
+	pixel_y = -1
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "wxT" = (
@@ -34724,8 +34793,8 @@
 /area/rogue/indoors/town)
 "xto" = (
 /obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
+	icon_state = "largetable";
+	dir = 12
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -35880,6 +35949,8 @@
 	icon_state = "longtable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "yfM" = (
@@ -135520,7 +135591,7 @@ sWi
 tSH
 fqz
 fqz
-cbX
+hRw
 nhz
 mGD
 jaa
@@ -135931,7 +136002,7 @@ tpS
 utn
 lnb
 lqk
-nhz
+jWK
 ueB
 cte
 rDz
@@ -136139,7 +136210,7 @@ cte
 ifd
 ubI
 dIC
-lDA
+qWz
 xsa
 nhz
 kqj
@@ -137146,7 +137217,7 @@ hRw
 otT
 nqn
 bSd
-wco
+jOS
 drT
 nqn
 dqQ
@@ -170472,8 +170543,8 @@ qoQ
 sLq
 bEj
 hRw
-bEj
-bEj
+koo
+enj
 dhw
 wxO
 uRl
@@ -170673,7 +170744,7 @@ xxw
 vIX
 tpu
 bEj
-jiz
+quv
 bEj
 bEj
 gvk
@@ -171086,7 +171157,7 @@ bEj
 bEj
 quv
 oan
-dFV
+gXc
 bEj
 bEj
 mEa
@@ -171284,8 +171355,8 @@ oan
 dFV
 bEj
 bEj
-bEj
-bEj
+tem
+peF
 hRw
 ufU
 lFi
@@ -171483,11 +171554,11 @@ hxO
 iaH
 nkE
 bEj
-bEj
+mhy
 hRw
 hhT
-bEj
-bEj
+tem
+cbX
 hRw
 hRw
 hRw
@@ -171689,7 +171760,7 @@ hRw
 hRw
 hRw
 nwi
-bEj
+jiz
 hRw
 gTu
 bcc
@@ -172092,7 +172163,7 @@ hRw
 hRw
 hRw
 hRw
-bEj
+koo
 bEj
 hRw
 gTu

--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -595,7 +595,10 @@
 	pixel_x = -5;
 	pixel_y = -1
 	},
-/turf/open/floor/rogue/twig,
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig/platform,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -3419,14 +3422,17 @@
 /area/rogue/under/cavewet/bogcaves)
 "cvo" = (
 /obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = -1
 	},
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/twig/platform,
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -24363,6 +24369,7 @@
 	color = "grey"
 	},
 /obj/structure/closet/crate/roguecloset,
+/obj/item/roguekey/tailor,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "qoW" = (
@@ -28616,9 +28623,12 @@
 	})
 "tfh" = (
 /obj/structure/fluff/railing/wood{
-	pixel_y = -8
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/twig/platform,
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -28656,10 +28666,9 @@
 	})
 "tgt" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
@@ -29150,7 +29159,7 @@
 /obj/structure/fluff/railing/wood{
 	pixel_y = -8
 	},
-/turf/open/floor/rogue/twig,
+/turf/open/floor/rogue/twig/platform,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -30181,6 +30190,7 @@
 /area/rogue/indoors/shelter/town)
 "ufU" = (
 /obj/structure/closet/crate/roguecloset,
+/obj/item/roguekey/tailor,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town)
 "ufX" = (
@@ -31295,9 +31305,9 @@
 	pixel_y = 7
 	},
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
@@ -31728,15 +31738,7 @@
 /area/rogue/under/cavewet/bogcaves)
 "vey" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
+	pixel_y = -8
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
@@ -203072,11 +203074,11 @@ aZy
 aZy
 aZy
 aZy
-uQB
-jEp
-avG
-avG
 cvo
+jEp
+tgt
+tgt
+avG
 aZy
 aZy
 aZy
@@ -203274,11 +203276,11 @@ aZy
 aZy
 aZy
 aZy
-tgt
+tfh
 wSd
 wSd
 qqJ
-tfh
+txB
 aZy
 aZy
 aZy
@@ -203476,11 +203478,11 @@ aZy
 aZy
 aZy
 aZy
-tgt
+tfh
 wSd
 wSd
 wSd
-txB
+vey
 aZy
 aZy
 aZy
@@ -203678,7 +203680,7 @@ aZy
 aZy
 aZy
 aZy
-vey
+uQB
 kTR
 fhl
 fhl

--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -591,14 +591,14 @@
 	})
 "avG" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
-	first_time_text = "Stonehedge"
+	first_time_text = "Stonehedge Borders";
+	name = "far stonehedge"
 	})
 "awc" = (
 /obj/structure/flora/grass/jungle/b,
@@ -3418,18 +3418,18 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
 "cvo" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
 	},
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	pixel_y = -8
 	},
-/turf/open/floor/rogue/grass,
+/turf/open/floor/rogue/twig/platform,
 /area/rogue/outdoors{
-	first_time_text = "Stonehedge"
+	first_time_text = "Stonehedge Borders";
+	name = "far stonehedge"
 	})
 "cvD" = (
 /obj/structure/fermenting_barrel,
@@ -11557,7 +11557,15 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
 	},
-/turf/closed/wall/mineral/rogue/wooddark,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -14080,13 +14088,12 @@
 	first_time_text = "Stonehedge"
 	})
 "jEp" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
 /obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
@@ -14579,13 +14586,8 @@
 	name = "far stonehedge"
 	})
 "jUO" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
 /obj/structure/flora/grass/jungle/b,
-/turf/open/floor/rogue/twig/platform,
+/turf/open/transparent/openspace,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -28614,17 +28616,12 @@
 	})
 "tfh" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	pixel_y = -8
 	},
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/twig/platform,
 /area/rogue/outdoors{
-	first_time_text = "Stonehedge"
+	first_time_text = "Stonehedge Borders";
+	name = "far stonehedge"
 	})
 "tfn" = (
 /obj/item/natural/stone,
@@ -28658,16 +28655,13 @@
 	first_time_text = "The Twilight Woods"
 	})
 "tgt" = (
-/obj/structure/flora/newbranch{
-	dir = 4
-	},
 /obj/structure/fluff/railing/wood{
 	dir = 1;
 	layer = 2.7;
-	pixel_x = 2;
+	pixel_x = 1;
 	pixel_y = 7
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -29153,10 +29147,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
 "txB" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -31294,18 +31288,21 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/woods/grove)
 "uQB" = (
-/obj/structure/stairs{
-	dir = 8
-	},
 /obj/structure/fluff/railing/wood{
 	dir = 1;
 	layer = 2.7;
 	pixel_x = 1;
 	pixel_y = 7
 	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
-	first_time_text = "Stonehedge"
+	first_time_text = "Stonehedge Borders";
+	name = "far stonehedge"
 	})
 "uQJ" = (
 /obj/structure/fluff/railing/wood{
@@ -31733,10 +31730,15 @@
 /obj/structure/fluff/railing/wood{
 	dir = 1;
 	layer = 2.7;
-	pixel_x = 2;
+	pixel_x = 1;
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/twig/platform,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -32231,12 +32233,6 @@
 	name = "far stonehedge"
 	})
 "vzP" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors{
@@ -132987,7 +132983,7 @@ vrE
 sPO
 sPO
 sLh
-cvo
+sPO
 vzP
 qnW
 qnW
@@ -167732,8 +167728,8 @@ gue
 gue
 bcc
 gue
-uQB
-avG
+bcc
+bcc
 bcc
 bcc
 gue
@@ -167934,8 +167930,8 @@ bcc
 bcc
 bcc
 bcc
-tfh
-avG
+bcc
+bcc
 bcc
 bcc
 bcc
@@ -202070,7 +202066,7 @@ aZy
 aZy
 aZy
 aZy
-vey
+aZy
 oZz
 oZz
 oZz
@@ -202272,7 +202268,7 @@ aZy
 aZy
 aZy
 aZy
-vey
+aZy
 oZz
 oZz
 oZz
@@ -202474,11 +202470,11 @@ aZy
 aZy
 aZy
 aZy
-vey
-kTR
+aZy
+aZy
 jUO
-rSp
-sJC
+aZy
+oZz
 aZy
 aZy
 aZy
@@ -202676,10 +202672,10 @@ aZy
 aZy
 aZy
 oZz
-vey
-tgt
+aZy
+nXU
 oZz
-txB
+aZy
 aZy
 aZy
 aZy
@@ -202875,11 +202871,11 @@ aZy
 aZy
 aZy
 aZy
-itq
-itq
-itq
-vey
-tzc
+aZy
+aZy
+aZy
+aZy
+aZy
 aZy
 aZy
 aZy
@@ -203076,12 +203072,12 @@ aZy
 aZy
 aZy
 aZy
-dhs
+uQB
 jEp
-wSd
-wSd
-jQX
-tzc
+avG
+avG
+cvo
+aZy
 aZy
 aZy
 aZy
@@ -203278,12 +203274,12 @@ aZy
 aZy
 aZy
 aZy
-aZy
-yhI
+tgt
+wSd
 wSd
 qqJ
-jQX
-tzc
+tfh
+aZy
 aZy
 aZy
 aZy
@@ -203480,12 +203476,12 @@ aZy
 aZy
 aZy
 aZy
-yhI
+tgt
 wSd
 wSd
 wSd
-wSd
-tzc
+txB
+aZy
 aZy
 aZy
 aZy
@@ -203682,8 +203678,8 @@ aZy
 aZy
 aZy
 aZy
-aZy
 vey
+kTR
 fhl
 fhl
 hTL
@@ -203885,8 +203881,8 @@ aZy
 aZy
 aZy
 aZy
-vey
-tzc
+aZy
+aZy
 aZy
 aZy
 aZy
@@ -204087,8 +204083,8 @@ aZy
 aZy
 aZy
 aZy
-vey
-tzc
+aZy
+aZy
 aZy
 aZy
 aZy
@@ -204289,8 +204285,8 @@ aZy
 aZy
 aZy
 aZy
-vey
-tzc
+aZy
+aZy
 aZy
 aZy
 aZy
@@ -204491,8 +204487,8 @@ aZy
 aZy
 aZy
 aZy
-vey
-tzc
+aZy
+aZy
 aZy
 aZy
 aZy
@@ -204693,8 +204689,8 @@ aZy
 aZy
 aZy
 aZy
-vey
-tzc
+aZy
+aZy
 aZy
 aZy
 aZy
@@ -204895,8 +204891,8 @@ aZy
 aZy
 aZy
 aZy
-vey
-tzc
+aZy
+aZy
 aZy
 aZy
 aZy
@@ -205097,8 +205093,8 @@ aZy
 aZy
 aZy
 aZy
-vey
-tzc
+aZy
+aZy
 aZy
 aZy
 aZy

--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -591,9 +591,17 @@
 	})
 "avG" = (
 /obj/structure/fluff/railing/wood{
-	pixel_y = -8
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/open/floor/rogue/twig/platform,
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -3417,15 +3425,9 @@
 /area/rogue/under/cavewet/bogcaves)
 "cvo" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
@@ -4884,12 +4886,22 @@
 /turf/open/floor/rogue/blocks/stone/stonepattern3,
 /area/rogue/under/cavewet)
 "dsQ" = (
-/obj/structure/flora/newleaf{
-	dir = 8;
-	icon_state = "branch-end1"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors{
+	first_time_text = "Stonehedge Borders";
+	name = "far stonehedge"
+	})
 "duf" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newleaf{
@@ -9743,12 +9755,14 @@
 	first_time_text = "The Twilight Woods"
 	})
 "gBt" = (
-/obj/structure/flora/newleaf{
-	dir = 4;
-	icon_state = "branch-end1"
+/obj/structure/fluff/railing/wood{
+	pixel_y = -8
 	},
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors{
+	first_time_text = "Stonehedge Borders";
+	name = "far stonehedge"
+	})
 "gBA" = (
 /obj/structure/flora/roguetree/happyrandom{
 	desc = "An old, beloved tree that even elves could love.";
@@ -14175,11 +14189,10 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/shelter/town)
 "jHV" = (
-/obj/structure/flora/newleaf{
-	icon_state = "branch-end1"
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
 	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood/platform,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "jHZ" = (
 /obj/structure/roguewindow/openclose,
@@ -24604,13 +24617,6 @@
 /area/rogue/outdoors/woods{
 	first_time_text = "The Twilight Woods"
 	})
-"qwr" = (
-/obj/structure/flora/newleaf{
-	dir = 1;
-	icon_state = "branch-end1"
-	},
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town)
 "qwx" = (
 /mob/living/carbon/human/species/human/smartnpc/townguard/sentry,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -28618,18 +28624,6 @@
 	first_time_text = "The Sylver Dragonne..";
 	name = "Silver Dragon"
 	})
-"tfh" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors{
-	first_time_text = "Stonehedge Borders";
-	name = "far stonehedge"
-	})
 "tfn" = (
 /obj/item/natural/stone,
 /turf/open/water/swamp/deep,
@@ -28663,17 +28657,9 @@
 	})
 "tgt" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
+	pixel_y = -8
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/twig,
+/turf/open/floor/rogue/twig/platform,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -28820,16 +28806,6 @@
 /obj/effect/particle_effect/smoke,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave/minotaurcave)
-"tiG" = (
-/obj/structure/flora/newleaf{
-	icon_state = "branch-extend"
-	},
-/obj/structure/ladder,
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors{
-	first_time_text = "Stonehedge Borders";
-	name = "far stonehedge"
-	})
 "tjr" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/town)
@@ -29160,14 +29136,12 @@
 /area/rogue/under/cavewet/bogcaves)
 "txB" = (
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/obj/structure/fluff/railing/wood{
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/twig/platform,
+/turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -31305,17 +31279,6 @@
 /obj/structure/chair/arrestchair,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/woods/grove)
-"uQB" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors{
-	first_time_text = "Stonehedge Borders";
-	name = "far stonehedge"
-	})
 "uQJ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -31740,9 +31703,14 @@
 /area/rogue/under/cavewet/bogcaves)
 "vey" = (
 /obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/structure/fluff/railing/wood{
 	pixel_y = -8
 	},
-/turf/open/floor/rogue/twig,
+/turf/open/floor/rogue/twig/platform,
 /area/rogue/outdoors{
 	first_time_text = "Stonehedge Borders";
 	name = "far stonehedge"
@@ -170953,7 +170921,7 @@ wxB
 olY
 dgC
 bEj
-dsQ
+hRw
 oAL
 aKb
 hRw
@@ -171154,8 +171122,8 @@ bcc
 dww
 hRw
 hRw
-qwr
-xjn
+hRw
+hRw
 jHV
 oYD
 rqb
@@ -171357,7 +171325,7 @@ bcc
 hRw
 jsC
 iaH
-gBt
+hRw
 oan
 dFV
 bEj
@@ -203076,11 +203044,11 @@ aZy
 aZy
 aZy
 aZy
-tgt
+dsQ
 jEp
-uQB
-uQB
-txB
+cvo
+cvo
+vey
 aZy
 aZy
 aZy
@@ -203278,11 +203246,11 @@ aZy
 aZy
 aZy
 aZy
-tfh
+txB
 wSd
 wSd
 qqJ
-avG
+tgt
 aZy
 aZy
 aZy
@@ -203480,11 +203448,11 @@ aZy
 aZy
 aZy
 aZy
-tfh
+txB
 wSd
 wSd
 wSd
-vey
+gBt
 aZy
 aZy
 aZy
@@ -203682,7 +203650,7 @@ aZy
 aZy
 aZy
 aZy
-cvo
+avG
 kTR
 fhl
 fhl
@@ -206103,7 +206071,7 @@ ezT
 emL
 emL
 dRc
-tiG
+duf
 duf
 yaD
 tVr

--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -591,11 +591,6 @@
 	})
 "avG" = (
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/structure/fluff/railing/wood{
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/twig/platform,
@@ -3428,9 +3423,9 @@
 	pixel_y = 7
 	},
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
@@ -19350,7 +19345,9 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/structure/roguemachine/merchantvend,
+/obj/structure/roguemachine/merchantvend{
+	lockid = "tailor"
+	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town)
 "ndV" = (
@@ -28666,6 +28663,12 @@
 	})
 "tgt" = (
 /obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = -1
@@ -29156,6 +29159,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves)
 "txB" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
 /obj/structure/fluff/railing/wood{
 	pixel_y = -8
 	},
@@ -31299,15 +31307,9 @@
 /area/rogue/outdoors/woods/grove)
 "uQB" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors{
@@ -203074,11 +203076,11 @@ aZy
 aZy
 aZy
 aZy
-cvo
+tgt
 jEp
-tgt
-tgt
-avG
+uQB
+uQB
+txB
 aZy
 aZy
 aZy
@@ -203280,7 +203282,7 @@ tfh
 wSd
 wSd
 qqJ
-txB
+avG
 aZy
 aZy
 aZy
@@ -203680,7 +203682,7 @@ aZy
 aZy
 aZy
 aZy
-uQB
+cvo
 kTR
 fhl
 fhl

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -292,6 +292,8 @@
 
 #define JDO_MASON 22
 
+#define JDO_TAILOR 23
+
 #define JDO_BARKEEP 26
 #define JDO_COOK 27
 

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -148,6 +148,12 @@
 	icon_state = "hornkey"
 	lockid = "tavern"
 
+/obj/item/roguekey/tailor
+	name = "tailor key"
+	desc = "This key should open and close the tailor shop."
+	icon_state = "brownkey"
+	lockid = "tailor"
+
 /obj/item/roguekey/velder
 	name = "elder's key"
 	desc = "This key should open and close the elder's home."

--- a/code/modules/farming/fermenting_barrel.dm
+++ b/code/modules/farming/fermenting_barrel.dm
@@ -107,9 +107,9 @@
 	. = ..()
 	reagents.add_reagent(/datum/reagent/consumable/ethanol/ale, rand(0,300))
 
-/obj/structure/fermenting_barrel/random/beer/wine/Initialize()
+/obj/structure/fermenting_barrel/random/wine/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/wine, rand(0,300))
+	reagents.add_reagent(/datum/reagent/consumable/ethanol/wine, rand(0,300))
 
 /obj/structure/fermenting_barrel/random/beer/cider/Initialize()
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
@@ -26,6 +26,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather/cloth/lady
 	beltr = /obj/item/rogueweapon/huntingknife/scissors
+	beltl = /obj/item/roguekey/tailor
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(/obj/item/natural/cloth = 2, /obj/item/natural/bundle/fibers/full = 1)
 	H.change_stat("intelligence", 2)

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -3,8 +3,8 @@
 	flag = TAILOR
 	department_flag = YEOMEN
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 
 	allowed_races = RACES_ALL_KINDSPLUS
 

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -3,26 +3,56 @@
 	flag = TAILOR
 	department_flag = YEOMEN
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 2
+	spawn_positions = 2
+
+	allowed_races = RACES_ALL_KINDSPLUS
+
+	tutorial = "For years, you've honed your craft in the quiet hum of sewing rooms and bustling marketplaces. From mending humble garments to creating luxurious attire fit for royalty, your hands have become unmatched in the art of needle and thread."
 
 	outfit = /datum/outfit/job/roguetown/tailor
 	outfit_female = /datum/outfit/job/roguetown/tailor/female
-	display_order = 6
+	display_order = JDO_TAILOR
 	min_pq = 0
-	allowed_races = RACES_ALL_KINDSPLUS
+	max_pq = null
 
-/datum/outfit/job/roguetown/tailor
-	name = "Tailor"
-	jobtype = /datum/job/roguetown/tailor
-
-	pants = /obj/item/clothing/under/roguetown/tights
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-	armor = /obj/item/clothing/suit/roguetown/shirt/rags
-	shoes = /obj/item/clothing/shoes/roguetown/boots
-
-/datum/outfit/job/roguetown/tailor/female
-	name = "Tailor"
-	jobtype = /datum/job/roguetown/tailor
-
-	pants = null
+/datum/outfit/job/roguetown/tailor/pre_equip(mob/living/carbon/human/H)
+	..()
+	if(H.mind)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/sewing, 5, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/labor/farming, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/craft/hunting, 4, TRUE)
+		H.change_stat("intelligence", 2)
+		H.change_stat("speed", 2)
+		H.change_stat("perception", 3)
+		if(isseelie(H))
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/seelie_dust)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/summon_rat)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/strip)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/seelie_kiss)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/splash)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/roustame)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/animate_object)
+		neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		beltr = /obj/item/rogueweapon/huntingknife/scissors
+		beltl = /obj/item/roguekey/tailor
+		backl = /obj/item/storage/backpack/rogue/satchel
+		backpack_contents = list(/obj/item/natural/cloth = 2, /obj/item/natural/bundle/fibers/full = 1)
+		id = /obj/item/scomstone
+		if(H.pronouns == SHE_HER)
+			armor = /obj/item/clothing/suit/roguetown/armor/armordress
+			shirt = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress
+			pants = /obj/item/clothing/under/roguetown/tights/random
+			cloak = /obj/item/clothing/cloak/raincloak/furcloak
+			belt = /obj/item/storage/belt/rogue/leather/cloth/lady
+		else
+			armor = /obj/item/clothing/suit/roguetown/shirt/rags
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+			pants = /obj/item/clothing/under/roguetown/trou
+			cloak = /obj/item/clothing/cloak/apron/waist/brown
+			belt = /obj/item/storage/belt/rogue/leather

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -11,7 +11,6 @@
 	tutorial = "For years, you've honed your craft in the quiet hum of sewing rooms and bustling marketplaces. From mending humble garments to creating luxurious attire fit for royalty, your hands have become unmatched in the art of needle and thread."
 
 	outfit = /datum/outfit/job/roguetown/tailor
-	outfit_female = /datum/outfit/job/roguetown/tailor/female
 	display_order = JDO_TAILOR
 	min_pq = 0
 	max_pq = null

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/roguetown/tailor
 	display_order = JDO_TAILOR
+	give_bank_account = 300
 	min_pq = 0
 	max_pq = null
 


### PR DESCRIPTION
## About The Pull Request

Readds the tailor's job, adds more tailor spawns in the tailor shop + towner spawns within the shop as well. The tailor's job is akin to the innkeeper but for the tailor, thus being them the owner of the shop and having the choice to hire towner seamsters/seamstresses to work with them.

Moved the tailor shop's vomitorium to a site where it can actually be noticed by people working in it. Removed the tailor's roof access and the top z-level bridge path.

Added the tailor's key, to finally make the tailor shop secure. All tailor doors (except the entrance for obvious reasons) now start locked. I've also chosen to give such key to towner seamsters because I doubt whether there will be people who choose to play tailor as a full-time job.

Also edited the new tavern cellar's lighting and fixed the wine barrel not having wine in it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Low impact whatsoever on the balance, besides that tailors start off similarly as rich as the innkeeper (slightly less), they have actual ownership of the shop + if there's no tailor or towner seamstress and one desires to powergame all they have to do is 'apply weapon/lockpick to door' and done.

I'm looking forward to revitalizing the roles of crafters this way, we all know relying on other SS13 players is like blindly signing a multinational enterprise contract and selling your soul to god knows who, so it won't be perfect nor these changes will do much, but I think they lay down the foundations for it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
