### PR TITLE
Bugfixes and Stuff pt. 2

### DIFF
--- a/_maps/map_files/dreamhold/Dreamhold.dmm
+++ b/_maps/map_files/dreamhold/Dreamhold.dmm
@@ -13133,8 +13133,7 @@
 	},
 /area/rogue/outdoors/river)
 "iXt" = (
-/obj/structure/handcart,
-/obj/item/rogueweapon/stoneaxe/woodcut,
+/obj/structure/roguemachine/bounty,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison{
 	first_time_text = "Adventurers Guild";
@@ -19737,6 +19736,13 @@
 	icon_state = "road"
 	},
 /area/rogue/indoors/shelter/bog)
+"npR" = (
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/garrison{
+	first_time_text = "Adventurers Guild";
+	name = "Adventurers Guild"
+	})
 "npY" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -26560,8 +26566,8 @@
 	name = "Ravenloft Academy"
 	})
 "rIw" = (
-/turf/closed,
-/turf/closed/wall/mineral/rogue/stone/moss,
+/obj/structure/chair/arrestchair,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/garrison{
 	first_time_text = "Adventurers Guild";
 	name = "Adventurers Guild"
@@ -89356,7 +89362,7 @@ xDh
 xDh
 xDh
 lzV
-vxU
+gkJ
 eAD
 qgp
 vxU
@@ -89558,7 +89564,7 @@ prw
 xDh
 xDh
 xDh
-rIw
+gkJ
 qgp
 qgp
 vxU
@@ -89760,7 +89766,7 @@ rPi
 wpF
 xDh
 xDh
-rIw
+gkJ
 qgp
 qgp
 vxU
@@ -89961,8 +89967,8 @@ nVt
 rPi
 prw
 xDh
-xDh
-gkJ
+prw
+vxU
 qgp
 qgp
 vxU
@@ -90163,8 +90169,8 @@ rxm
 bFf
 prw
 prw
-xDh
-gkJ
+prw
+rIw
 qgp
 qgp
 qfv
@@ -90366,7 +90372,7 @@ bFf
 bFf
 prw
 prw
-gkJ
+npR
 qgp
 qgp
 xpu

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -391,6 +391,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NOEMBED			"noembed"
 #define TRAIT_T_RAY_VISIBLE     "t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1
 #define TRAIT_NO_TELEPORT		"no-teleport" //you just can't
+#define TRAIT_UNPICKPOCKETABLE  "unpickpocketable" //cannot be pickpocketed
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -500,6 +500,9 @@
 											stealpos.Add(V.get_item_by_slot(SLOT_SHOES))
 								if (length(stealpos) > 0)
 									var/obj/item/picked = pick(stealpos)
+									if(HAS_TRAIT(picked, TRAIT_UNPICKPOCKETABLE))
+										to_chat(src, span_warning("I can't seem to get a grip on [picked]!"))
+										return
 									V.dropItemToGround(picked)
 									put_in_active_hand(picked)
 									to_chat(src, span_green("I stole [picked]!"))

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -205,12 +205,10 @@
 		to_chat(user, span_alert("Roleplay accordingly to your collar's effects."))
 
 /obj/item/clothing/neck/roguetown/gorget/servant/canStrip(mob/living/carbon/human/stripper, mob/living/carbon/human/owner)
-	if(stripper.job == "Great Druid" || stripper.job == "Druid" || stripper.job == "Hedge Warden" || stripper.job == "Hedge Knight" || stripper.job == "Ovate")
-		to_chat(stripper, span_warning("I disable the collar's enchanted locking mechanism. It will only reactivate when worn again."))
+	if(stripper.job in list("Great Druid", "Druid", "Hedge Warden", "Hedge Knight", "Ovate"))
 		REMOVE_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 		return TRUE
-	else
-		return ..()
+	return FALSE
 
 /obj/item/clothing/neck/roguetown/gorget/servant/dropped(mob/user)
 	. = ..()

--- a/code/modules/roguetown/roguemachine/bounty.dm
+++ b/code/modules/roguetown/roguemachine/bounty.dm
@@ -29,6 +29,10 @@
 	var/list/choices = list("Consult Bounties", "Set Bounty", "Print List of Bounties")
 	if(user.job in list("Great Druid", "Druid", "Hedge Warden", "Hedge Knight", "Ovate"))
 		choices += "Remove Bounty"
+
+	if(user.job in list("Guildmaster", "Guild Appraiser"))
+		choices += "Set Bounty"
+
 	var/selection = input(user, "The Excidium listens", src) as null|anything in choices
 
 	switch(selection)

--- a/code/modules/roguetown/roguemachine/grove.dm
+++ b/code/modules/roguetown/roguemachine/grove.dm
@@ -12,6 +12,10 @@
 	var/last_distress = 0
 	var/distress_cooldown = 300
 
+/obj/item/clothing/neck/roguetown/psicross/dendor/grove/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_UNPICKPOCKETABLE, ROUNDSTART_TRAIT)
+
 /obj/item/clothing/neck/roguetown/psicross/dendor/grove/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	if(!proximity_flag)
@@ -304,7 +308,7 @@
 
 		var/old_density = target_tree.density
 		target_tree.density = FALSE
-		addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(restore_emergency_tree_density), target_tree, old_density), 10 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
+		addtimer(CALLBACK(GLOBAL_PROC, /proc/restore_emergency_tree_density, target_tree, old_density), 10 SECONDS, TIMER_UNIQUE | TIMER_STOPPABLE)
 
 		playsound(target_tree, 'sound/misc/treefall.ogg', 50, TRUE)
 		new /obj/effect/temp_visual/grove_portal_transit(get_turf(target_tree))

--- a/modular_stonehedge/code/game/objects/items/class_selectors.dm
+++ b/modular_stonehedge/code/game/objects/items/class_selectors.dm
@@ -9,6 +9,7 @@
 	var/datum/job/roguetown/intended_job
 	var/inventory_items = list()
 	var/classes = list()
+	var/used = FALSE
 
 /obj/item/class_selector/Initialize()
 	. = ..()
@@ -17,6 +18,10 @@
 
 //guildmaster
 /obj/item/class_selector/veteran/attack_self(mob/living/carbon/human/H)
+	if(used)
+		to_chat(H, span_warning("You've already chosen your class!"))
+		return
+	used = TRUE
 	. = ..()
 	//basicest classes basically
 	classes = list(
@@ -335,6 +340,10 @@
 	desc = "A leather-bound tome containing the specialized teachings of the Academy. It allows a mage to choose their magical focus."
 
 /obj/item/class_selector/acadmage/attack_self(mob/living/carbon/human/H)
+	if(used)
+		to_chat(H, span_warning("You've already chosen your specialization!"))
+		return
+	used = TRUE
 	. = ..()
 	classes = list(
 		"Spellweaver",
@@ -454,6 +463,10 @@
 	desc = "An ornate tome bound in rich leather and adorned with mystical runes. It contains the highest teachings of the Academy, allowing an Archmage to choose their mastery."
 
 /obj/item/class_selector/acadarchmage/attack_self(mob/living/carbon/human/H)
+	if(used)
+		to_chat(H, span_warning("You've already chosen your mastery!"))
+		return
+	used = TRUE
 	. = ..()
 	classes = list(
 		"Arcanist",
@@ -580,6 +593,10 @@
 
 //TEMPLE PALADIN
 /obj/item/class_selector/paladin/attack_self(mob/living/carbon/human/H)
+	if(used)
+		to_chat(H, span_warning("You've already chosen your weapon specialization!"))
+		return
+	used = TRUE
 	classes = list( //what did you primarily train with?
 		"Swords",
 		"Axes",


### PR DESCRIPTION
## Changelog
- Fixes the bug that prevents the Grove from removing collars
- Fixes the bug that doesn't return the tree's density to it's original position after an emergency waygate making them permanently walkthroughable and brick people who lean on it.
- Fixes the bug that allows people to click on their subclass book multiple times for multiple loadouts + skill increases.
- Excidium and POENA have been added to the Guild. Only the Guildmaster or Guild Appraiser can set bounties. Only the Guildmaster, Guild Appraiser, or Grove can remove bounties. Bounties are not hunted by the Grove, but by the Guild.
- Adds a trait which makes an item unpickpocketable. Intended to be reserved for ultra specialized items that are central to a job's duties and cannot be replaced in any IC way.