### PR TITLE
Eldritch Healing now has default text

### DIFF
--- a/code/modules/spells/roguetown/warlock.dm
+++ b/code/modules/spells/roguetown/warlock.dm
@@ -19,8 +19,8 @@
 	charge_max = 20 SECONDS
 	miracle = FALSE
 	var/patronname = ""
-	var/targetnotification = ""
-	var/othernotification = ""
+	var/targetnotification = "Shimmering arcane energy lessens my pain!" // This (and the line below) is a default message; Warlocks with patrons will have it overwritten in their job file.
+	var/othernotification = "is surrounded by shimmering arcane energy."
 	var/ignore_faithless = FALSE
 
 /obj/effect/proc_holder/spell/invoked/eldritchhealing/cast(list/targets, mob/living/user)


### PR DESCRIPTION
## About The Pull Request

PR title.

## Why It's Good For The Game

This was never a problem when only Warlocks got the spell through the proper patron allocation method. However, both scrolls and Zizo now give you eldritch healing directly, which skips the step where the flavor text is added. This leads to blank lines appearing every time someone who _isn't_ a warlock uses the spell. Warlock spell allocation overwrites the default (currently blank) notification text, so this will cause no change for them.