### PR TITLE
Changes what I assume was a typo + Adds the Fur Cloak to the loadout menu.

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -328,8 +328,8 @@
 	reqs = list(/obj/item/rogueore/iron = 4)
 	craftdiff = 4
 
-/datum/crafting_recipe/roguetown/alchemy/i2top // Keep topers and their trinkets cheap to prevent wealth creep. Cheap means of getting gem dust, for potions.
-	name = "transmute iron to toper"
+/datum/crafting_recipe/roguetown/alchemy/i2top // Keep topaz and their trinkets cheap to prevent wealth creep. Cheap means of getting gem dust, for potions.
+	name = "transmute iron to topaz"
 	result = list(/obj/item/roguegem/yellow = 1)
 	reqs = list(
 		/obj/item/rogueore/iron = 1, //Toper will be worth 30 mammon. Iron ingot is worth 25.

--- a/modular_hearthstone/code/datums/loadout.dm
+++ b/modular_hearthstone/code/datums/loadout.dm
@@ -64,7 +64,6 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Rider Cloak"
 	path = /obj/item/clothing/cloak/half/rider did not port from Azure*/
 
-
 //SHOES
 /datum/loadout_item/darkboots
 	name = "Dark Boots"

--- a/modular_hearthstone/code/datums/loadout.dm
+++ b/modular_hearthstone/code/datums/loadout.dm
@@ -56,6 +56,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Halfcloak"
 	path = /obj/item/clothing/cloak/half
 
+/datum/loadout_item/Fur_Cloak
+    name = "Fur Cloak"
+	path = /obj/item/clothing/cloak/raincloak/furcloak
+
 /*/datum/loadout_item/ridercloak
 	name = "Rider Cloak"
 	path = /obj/item/clothing/cloak/half/rider did not port from Azure*/

--- a/modular_hearthstone/code/datums/loadout.dm
+++ b/modular_hearthstone/code/datums/loadout.dm
@@ -56,9 +56,11 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Halfcloak"
 	path = /obj/item/clothing/cloak/half
 
-/datum/loadout_item/Fur_Cloak
-    name = "Fur Cloak"
+/datum/loadout_item/furcloak
+	name = "Fur Cloak"
 	path = /obj/item/clothing/cloak/raincloak/furcloak
+
+
 
 /*/datum/loadout_item/ridercloak
 	name = "Rider Cloak"


### PR DESCRIPTION
## About The Pull Request

<Changes "Transmute iron to toper" to "Transmute Iron to topaz". Basically just fixing what I assume was a minor spelling mistake. Note that this doesn't change "toper" anywhere else in the code, only what the recipe says it'll make. 

Adds the fur cloak to the loadout menu. Without the spaces between 61-65 it returns an inconsistent indentation error. 

Both ran without issue. >

## Why It's Good For The Game
<--This is more of a test PR to see if I can do something small without breaking something, seeing as I have no experience. If it succeeds, I'll (hopefully) be able to move on to doing smaller things people may want. The fur cloak is also just a loadout-worthy item, let people have drip roundstart... -->
