### PR TITLE
Lasinn's assorted tweaks, round 1

### DIFF
--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -40,19 +40,6 @@
 	static_price = FALSE
 	mill_result = /obj/item/reagent_containers/powder/rontz
 
-/obj/item/roguegem/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item))
-		var/obj/item/I = W
-		if(HAS_TRAIT(user, TRAIT_ARTIFICER))
-			if(W.infusable)
-				user.dropItemToGround(W, TRUE)
-				W.AddComponent(/datum/component/infusions, user, src, FALSE)
-			else
-				to_chat(user, span_warning("[I] is already infused!"))
-		else
-			to_chat(user, span_warning("I'm no artificer!"))
-	..()
-
 /obj/item/reagent_containers/powder/rontz
 	name = "ruby dust"
 	desc = ""
@@ -268,3 +255,16 @@
 	grind_results = list(
 		/datum/reagent/gemdust = 5,
 		/datum/reagent/medicine/manapot = 25)
+
+/obj/item/riddleofsteel/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item))
+		var/obj/item/I = W
+		if(HAS_TRAIT(user, TRAIT_ARTIFICER))
+			if(W.infusable)
+				user.dropItemToGround(W, TRUE)
+				W.AddComponent(/datum/component/infusions, user, src, FALSE)
+			else
+				to_chat(user, span_warning("[I] is already infused!"))
+		else
+			to_chat(user, span_warning("I'm no artificer!"))
+	..()

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -548,3 +548,105 @@
 				/obj/item/natural/fibers = 1,
 				)
 	craftdiff = 1
+
+/// ADVANCED LEATHER
+
+/datum/crafting_recipe/roguetown/leather/advboots
+	name = "hardened leather boots"
+	result = /obj/item/clothing/shoes/roguetown/boots/armor/leather/advanced
+	reqs = list(/obj/item/natural/hide/cured = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/leather/advgloves
+	name = "hardened leather gloves"
+	result = /obj/item/clothing/gloves/roguetown/leather/advanced
+	reqs = list(/obj/item/natural/hide/cured = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/leather/advcoat
+	name = "hardened leather coat"
+	result = /obj/item/clothing/suit/roguetown/armor/leather/advanced
+	reqs = list(/obj/item/natural/hide/cured = 2,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/leather/advhelmet
+	name = "hardened leather helmet"
+	result = /obj/item/clothing/head/roguetown/helmet/leather/advanced
+	reqs = list(/obj/item/natural/hide/cured = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/leather/advneck
+	name = "hardened leather gorget"
+	result = /obj/item/clothing/neck/roguetown/gorget/leather
+	reqs = list(/obj/item/natural/hide/cured = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/leather/advchausses
+	name = "hardened leather chausses"
+	result = /obj/item/clothing/under/roguetown/trou/leather/advanced
+	reqs = list(/obj/item/natural/hide/cured = 2,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 4
+
+/// MASTERWORK
+
+/datum/crafting_recipe/roguetown/leather/advboots/masterwork
+	name = "masterwork leather boots"
+	result = /obj/item/clothing/shoes/roguetown/boots/armor/leather/masterwork
+	reqs = list(/obj/item/natural/hide/cured = 2,
+				/obj/item/natural/cured/essence = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/leather/advgloves/masterwork
+	name = "masterwork leather gloves"
+	result = /obj/item/clothing/gloves/roguetown/leather/masterwork
+	reqs = list(/obj/item/natural/hide/cured = 2,
+				/obj/item/natural/cured/essence = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/leather/advbracers/masterwork
+	name = "masterwork leather bracers"
+	result = /obj/item/clothing/wrists/roguetown/bracers/leather/masterwork
+	reqs = list(/obj/item/natural/hide/cured = 2,
+				/obj/item/natural/cured/essence = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/leather/advcoat/masterwork
+	name = "masterwork leather coat"
+	result = /obj/item/clothing/suit/roguetown/armor/leather/masterwork
+	reqs = list(/obj/item/natural/hide/cured = 4,
+				/obj/item/natural/cured/essence = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/leather/advhelmet/masterwork
+	name = "masterwork leather helmet"
+	result = /obj/item/clothing/head/roguetown/helmet/leather/masterwork
+	reqs = list(/obj/item/natural/hide/cured = 2,
+				/obj/item/natural/cured/essence = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/leather/advstudhood/masterwork
+	name = "masterwork leather studded hood"
+	result = /obj/item/clothing/head/roguetown/helmet/leather/armorhood/masterwork
+	reqs = list(/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced = 1,
+				/obj/item/natural/cured/essence = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/leather/advchausses/masterwork
+	name = "masterwork leather chausses"
+	result = /obj/item/clothing/under/roguetown/trou/leather/masterwork
+	reqs = list(/obj/item/natural/hide/cured = 3,
+				/obj/item/natural/cured/essence = 1,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 5

--- a/code/modules/roguetown/roguejobs/tailor/tanning.dm
+++ b/code/modules/roguetown/roguejobs/tailor/tanning.dm
@@ -51,7 +51,7 @@
 			user.mind.adjust_experience(/datum/skill/craft/hunting, user.STAINT * 2) //these numbers may need some revision
 			update_icon()
 			for(var/i = 0; i < pieces_to_spawn; i++)
-				if(prob(skill_level + user.goodluck(2)))
+				if(prob(skill_level + user.goodluck(2) + 10))
 					new /obj/item/natural/cured/essence(get_turf(user))
 					if(!sound_played)
 						sound_played = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Infusing items with an enchantment now requires the use of a riddle of steel instead of other gems.
- +10% drop chance of essence of wilderness when curing hides
- Hardened and Masterwork leather items can now be made with the Hunting skill; They can still be made with the sewing skill, too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Due to the way infusions worked, artificers could use any gem to give out basically free enchantments en masse. Rather than nerf alchemy to make all gems harder to acquire, however, we have instead opted to make infusions themselves more expensive to acquire.
- The current drop rate of essence of wilderness, even with boosted luck and maxed out skills, means that in controlled testing, it took 1.5 hours to acquire enough to make a full set. The added drop rate should greatly alleviate this problem.
- It didn't make sense that making leather armor was almost exclusive to the sewing skill, but it also didn't make sense to restrict it solely to the hunting skill either. Now you can use either for making leather armor.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
