### PR TITLE
Guild Physician

### DIFF
--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -516,16 +516,14 @@
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 42
 	STR.set_holdable(list(
-		/obj/item/reagent_containers/hypospray/medipen/sealbottle/reju,
-		/obj/item/reagent_containers/hypospray/medipen/sty/detox,
-		/obj/item/natural/cloth/bandage,
-		/obj/item/natural/bundle/cloth/bandage,
-		/obj/item/natural/bundle/cloth/bandage/full,
-		/obj/item/reagent_containers/pill/pnkpill,
+		/obj/item/reagent_containers/hypospray/, //all injectards
+		/obj/item/natural/cloth/,
+		/obj/item/natural/bundle/cloth/, //all cloth and bandage
+		/obj/item/reagent_containers/, //all pills-drugs
 		/obj/item/candle,
-		/obj/item/needle,
-		/obj/item/needle/thorn,
-		/obj/item/needle/pestra,
+		/obj/item/needle/,
+		/obj/item/reagent_containers/glass/bottle/rogue/, //all bottles
+		/obj/item/storage/fancy/, //pilltins, you can put a ifak inside a ifak
 	))
 
 /obj/item/storage/fancy/ifak/PopulateContents()

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -25,7 +25,6 @@
 /datum/outfit/job/roguetown/physician
 	name = "Physician"
 	jobtype = /datum/job/roguetown/physician
-	allowed_patrons = list(/datum/patron/divine/hermeir)
 
 /datum/outfit/job/roguetown/physician/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -44,35 +43,35 @@
 	r_hand = /obj/item/rogueweapon/woodstaff
 	backl = /obj/item/storage/backpack/rogue/backpack
 	backpack_contents = list(
-		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 2,
-		/obj/item/needle/pestra = 1,
-		/obj/item/rogueweapon/surgery/scalpel = 1,
-		/obj/item/rogueweapon/surgery/saw = 1,
-		/obj/item/rogueweapon/surgery/hemostat = 2, //2 forceps so you can clamp bleeders AND manipulate organs
-		/obj/item/rogueweapon/surgery/retractor = 1,
-		/obj/item/rogueweapon/surgery/bonesetter = 1,
-		/obj/item/rogueweapon/surgery/cautery = 1,
-		/obj/item/natural/worms/leech/cheele = 1, //little buddy
+		/obj/item/reagent_containers/glass/alembic = 1,
+		/obj/item/storage/fancy/ifak = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
+		/obj/item/clothing/mask/rogue/physician = 1,
+		/obj/item/storage/box/matches = 1, /// for carterizer and ring.
+		/obj/item/flashlight/flare/torch/lantern/ring = 1, //lantern+
+		/obj/item/storage/fancy/skit = 1,
 	)
 	ADD_TRAIT(H, TRAIT_EMPATH, "[type]")
+	ADD_TRAIT(H, TRAIT_SELF_AWARE, "[type]") //can see exact numbers for diagnose
 	ADD_TRAIT(H, TRAIT_NOSTINK, "[type]")
 	if(H.mind)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/reading, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/alchemy, 5, TRUE)
-		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE)
+		H.mind.adjust_skillrank_up_to(/datum/skill/combat/polearms, 2, TRUE) //for the staff
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/craft/crafting, 3, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/sewing, 5, TRUE)
 		H.mind.adjust_skillrank_up_to(/datum/skill/misc/medicine, 6, TRUE)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
-		H.change_stat("strength", -1)
-		H.change_stat("constitution", -1)
-		H.change_stat("intelligence", 3)
+		H.change_stat("intelligence", 2) /// bumped these up by one and added some con. I cant rework everyclass but this one made me sad.
 		H.change_stat("fortune", 1)
-		H.change_stat("endurance", 1)
-		if(H.age == AGE_OLD)
-			H.change_stat("speed", -1)
-			H.change_stat("intelligence", 1)
-			H.change_stat("perception", 1)
+		H.change_stat("constitution", 2) // regular health checks to self. I dunno man give em something. miricles already shits all over surgery healin.
+		H.change_stat("speed", 2) // to get to the scene of injuries faster
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/docheal)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/stable)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/purge)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/debride)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/cpr)
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Makes the physician's loadout and stats, about the same as the pilgrim surgeon
Renames the physician to the Guild Physician to make it more obvious that they work in the guild's basement
Guild physician now has the sawbone surgeries, same as the pilgrim physician, therefore now able to revive and unrot people
additionally
IFAK can now contain all medicine, pilltins, bandages etc and no longer will be a throwaway item since it can only contain the spesific items it already had inside the bag

Note: no, with this change you cannot put a surgery kit or another IFAK inside an IFAK

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The guild physician in its current state has the following issues:
1. compared to the barber surgeon, which by the way, is a infinite slot pilgrim role... Useless. the barber surgeon gets way more gear, skills and is able to revive and unrot people, which the guild physician should be able to do so, but cannot for some fucking reason
2. The guild physician is simply called "Physician" and not "Guild Physician" this causes both the player playing it and the other players meeting them, confused, as they cannot tell if they are a guild worker or a adventurer physician
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
