### PR TITLE
Removes Embedding From Nonplayers

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -437,11 +437,7 @@
 		if(I.damtype == BRUTE)
 			next_attack_msg.Cut()
 			if(HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS))
-				var/datum/wound/crit_wound  = simple_woundcritroll(user.used_intent.blade_class, newforce, user, hitlim)
-				if(should_embed_weapon(crit_wound, I))
-					// throw_alert("embeddedobject", /atom/movable/screen/alert/embeddedobject)
-					simple_add_embedded_object(I, silent = FALSE, crit_message = TRUE)
-					src.grabbedby(user, 1, item_override = I)
+				simple_woundcritroll(user.used_intent.blade_class, newforce, user, hitlim)
 			var/haha = user.used_intent.blade_class
 			if(newforce > 5)
 				if(haha != BCLASS_BLUNT)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1657,7 +1657,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(!nodmg)
 			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block+armor))/100), user, selzone, crit_message = TRUE)
 			SEND_SIGNAL(I, COMSIG_APPLY_REAGENTS, affecting.owner, user)
-			if(should_embed_weapon(crit_wound, I))
+			if(H.mind && should_embed_weapon(crit_wound, I))
 				var/can_impale = TRUE
 				if(!affecting)
 					can_impale = FALSE


### PR DESCRIPTION
getting your weapon stuck in a mob and having them run off with it at lightning speed, or stuck in their face and someone else decapitates them and now your weapon just gets deleted.

neither of these add anything to the game. so. it doesn't happen anymore. simplemobs don't suffer embedding. human-like mobs don't suffer embedding unless they're controlled by a player