### PR TITLE
buffing acrhfey patron

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warlock.dm
@@ -141,10 +141,10 @@
 	H.change_stat("constitution", 1)
 
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/seelie_dust)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/strip)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/seelie_kiss)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/splash)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/animate_object)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/archfey_warlock_strip)
+    H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/archfey_warlock_seelie_kiss)
+    H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/summon_rat)
+    H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/roustame)
 
 	ADD_TRAIT(H, TRAIT_WILDMAGIC, TRAIT_GENERIC)
 

--- a/code/modules/spells/roguetown/archfey_warlock.dm
+++ b/code/modules/spells/roguetown/archfey_warlock.dm
@@ -1,0 +1,48 @@
+/obj/effect/proc_holder/spell/invoked/archfey_warlock_strip
+	name = "Strip Clothes"
+	overlay_state = "bcry"
+	releasedrain = 80
+	charge_max = 3 MINUTES
+	range = 1
+	cast_without_targets = TRUE
+	sound = 'sound/magic/churn.ogg'
+	invocation_type = "none" //can be none, whisper, emote and shout
+
+/obj/effect/proc_holder/spell/invoked/strip/cast(list/targets, mob/user)
+	. = ..()
+	user.emote("giggle")
+	var/mob/living/target = targets[1]
+	if(iscarbon(target))
+		var/obj/item/object = target.get_item_by_slot(pick(SLOT_GLOVES,SLOT_SHOES,SLOT_HEAD))
+		if(!istype(object, /obj/item/clothing/head/roguetown/helmet))//Can't take helmets!
+			target.dropItemToGround(object)
+		user.log_message("has stripped a piece of clothing from [key_name(target)] via spell", LOG_ATTACK)
+		target.log_message("has had a piece of clothing stripped by [key_name(user)] via spell", LOG_ATTACK)
+	return TRUE
+
+/obj/effect/proc_holder/spell/targeted/archfey_warlock_seelie_kiss
+	name = "Regenerative Kiss"
+	overlay_state = "heal"
+	releasedrain = 0
+	charge_max = 2 MINUTES
+	range = 1
+	invocation_type = "none" //can be none, whisper, emote and shout
+
+/obj/effect/proc_holder/spell/targeted/seelie_kiss/cast(list/targets, mob/user)
+	. = ..()
+	if(iscarbon(targets[1]))
+		var/mob/living/carbon/target = targets[1]
+		var/obj/item/reagent_containers/powder/K = new /obj/item/reagent_containers/powder/AFSK(target.loc)
+		K.reagents.trans_to(target, K.reagents.total_volume, transfered_by = user, method = "swallow")
+		target.add_nausea(9)
+		to_chat(target, span_notice("I suddenly feel reinvigorated!"))
+		to_chat(user, span_notice("I have reinvigorated [target] with a kiss."))
+		user.log_message("has blessed [key_name(target)] with a kiss spell, healing them a little", LOG_ATTACK)
+		target.log_message("has been blessed by [key_name(user)] with a kiss spell, healing them a little", LOG_ATTACK)
+		user.emote("kiss")
+		qdel(K)
+		return TRUE
+	return FALSE
+
+/obj/item/reagent_containers/powder/AFSK
+	list_reagents = list(/datum/reagent/medicine/healthpot = 12, /datum/reagent/medicine/manapot = 12) //i am pretty sure these numbers are in "U" whatever that is so this should be much? or enough to OD someone with, i also think the normal seelie kiss should be buffed but not this much


### PR DESCRIPTION
## About The Pull Request

Changes archfey patron warlocks to have it's own (untested and i am no coder) version of strip and seelie kiss

The kiss goes from 1u (0.3oz) of health and mana pot to 12u (4oz) and both get their cooldown halfed

Also replaces water bolt and animate object for spawn rat and tame mous

## Why It's Good For The Game

The main change i would like approved is for the kiss buff cause it has no use as it's in game right now but i don't want every seelie to have it because balance

The CD reduction for strip? i just think it's funny but also didn't want to buff every seelie with the spell

The change on the spell list is honestly my preference and entirely bias. I just think rats is a better gimmick than a spell that does nothing and animate object

## Possible issues

I do see an issue with these changes, since i cloned the seelie spells an archfey patron seelie warlock could have all of the 4 spells and i don't know how bad that would be

Also i am no coder so i don't know if it works and i am no game desinger so don't ask me about balance

## Final notes

I don't expect this to be approved but again i would be happy if the seelie kiss got buffed

PS: i don't play this game, my friend asked me to do this pr 