### PR TITLE
De-slops most spell incantations

### DIFF
--- a/code/modules/spells/roguetown/spells5e/cantrips5e.dm
+++ b/code/modules/spells/roguetown/spells5e/cantrips5e.dm
@@ -53,7 +53,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Acid splash!"
+	invocation = "Wear them away!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	ignore_fiendkiss = FALSE
 
@@ -143,7 +143,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Blade ward!"
+	invocation = "Blades, be dulled!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 // Notes: Bard, Sorcerer, Warlock, Wizard
 
@@ -203,7 +203,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Booming blade!"
+	invocation = "Stay still!" // Incantation should explain a confusing spell's mechanic.
 	invocation_type = "shout" //can be none, whisper, emote and shout
 
 /obj/effect/proc_holder/spell/invoked/boomingblade5e/cast(list/targets, mob/living/user)
@@ -287,7 +287,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Chill touch!"
+	invocation = "Be torn apart!"
 	invocation_type = "shout"
 	ignore_fiendkiss = FALSE
 
@@ -480,7 +480,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Decompose."
+	invocation = "Return to rot."
 	invocation_type = "whisper"
 
 /obj/effect/proc_holder/spell/invoked/decompose5e/cast(list/targets, mob/living/user)
@@ -557,7 +557,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Eldritch blast!"
+	invocation = "Eldritch blast!" // Bad incantation but it's funny.
 	invocation_type = "shout"
 	ignore_fiendkiss = FALSE
 
@@ -672,7 +672,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 1
-	invocation = "Firebolt!"
+	invocation = "Sear!"
 	invocation_type = "shout"
 	xp_gain = TRUE
 
@@ -718,7 +718,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Frostbite!"
+	invocation = "Freeze!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	ignore_fiendkiss = FALSE
 
@@ -838,7 +838,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Guidance."
+	invocation = "Light the path."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 
 
@@ -906,7 +906,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Infestation!"
+	invocation = "Rot, take them!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	ignore_fiendkiss = FALSE
 
@@ -1157,7 +1157,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Lightning lure!"
+	invocation = "Get back!" // This is INTENDED as a "get off me" tool, though rarely actually used for that. Also immediately explains what a target should do.
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	include_user = FALSE
 
@@ -1213,7 +1213,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Magic stone."
+	invocation = "Stay sharp and strong."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 	var/magic_color = "#c8daff"
 
@@ -1262,7 +1262,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Mending."
+	invocation = "Be reformed."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 
 /obj/effect/proc_holder/spell/invoked/mending5e/cast(list/targets, mob/living/user)
@@ -1314,7 +1314,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Mind Sliver!"
+	invocation = "Steal their thoughts!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	var/delay = 7
 	ignore_fiendkiss = FALSE
@@ -1452,7 +1452,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Primal savagery."
+	invocation = "Teeth of a serpent."
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 // Notes: Bard, Sorcerer, Warlock, Wizard
 
@@ -1508,7 +1508,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-	invocation = "Ray of Frost!"
+	invocation = "Chill!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	ignore_fiendkiss = FALSE
 

--- a/code/modules/spells/roguetown/warlock.dm
+++ b/code/modules/spells/roguetown/warlock.dm
@@ -13,8 +13,8 @@
 	movement_interrupt = FALSE
 	chargedloop = null
 	sound = 'sound/magic/heal.ogg'
-	invocation = "Eldritch healing!"
-	invocation_type = "shout"
+	invocation = "Wounds, be sealed."
+	invocation_type = "whisper"
 	associated_skill = /datum/skill/magic/arcane
 	antimagic_allowed = TRUE
 	charge_max = 20 SECONDS
@@ -77,6 +77,7 @@
 
 /datum/status_effect/buff/eldritchcurse
 	id = "eldritchcurse"
+	effectedstats = list("fortune" = -4) // This default case will be overridden for warlocks. Low luck is the closest to a "generic" curse, randomly failing a bit at everything.
 	alert_type = /atom/movable/screen/alert/status_effect/buff/eldritchcurse
 	duration = -1
 
@@ -124,7 +125,7 @@
 	xp_gain = FALSE
 	miracle = FALSE
 
-	invocation = "Cloak of flies!"
+	invocation = "Shield me with rot!"
 	invocation_type = "shout"
 	var/activated = FALSE
 	var/rot_type = /datum/component/rot/warlock
@@ -182,7 +183,7 @@
 	xp_gain = FALSE
 	miracle = FALSE
 
-	invocation = "Come forth familiar."
+	invocation = "Come forth, familiar."
 	invocation_type = "whisper"
 
 	var/mob/living/fam

--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -18,7 +18,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 3
-	invocation = "Lightning bolt!"
+	invocation = "Strike them down!"
 	invocation_type = "shout"
 	xp_gain = TRUE
 
@@ -116,7 +116,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	charging_slowdown = 3
-	invocation = "Blood bolt!"
+	invocation = "Strike them down!"
 	invocation_type = "shout"
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/blood
@@ -227,7 +227,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 4
-	invocation = "Fireball!"
+	invocation = "Burn!"
 	invocation_type = "shout"
 	xp_gain = TRUE
 
@@ -276,7 +276,7 @@
 	movement_interrupt = TRUE
 	chargedloop = /datum/looping_sound/invokegen
 	cost = 10
-	invocation = "FIREBALL!!!"
+	invocation = "Incinerate!"
 	invocation_type = "shout"
 	xp_gain = TRUE
 
@@ -311,7 +311,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 1
-	invocation = "Spitfire!"
+	invocation = "Char!"
 	invocation_type = "shout"
 	xp_gain = TRUE
 
@@ -481,7 +481,7 @@
 	charging_slowdown = 1
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	invocation = "Fetch."
+	invocation = "Come here."
 	invocation_type = "whisper"
 	cost = 2
 	xp_gain = TRUE
@@ -791,7 +791,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	var/wall_type = /obj/structure/forcefield_weak/caster
 	xp_gain = TRUE
-	invocation = "Forcewall!"
+	invocation = "Stay back!"
 	invocation_type = "shout"
 	cost = 3
 
@@ -865,7 +865,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	range = 6
 	overlay_state = "ensnare"
-	invocation = "Black tentacles!"
+	invocation = "Trip and fall!"
 	invocation_type = "shout"
 	var/area_of_effect = 1
 	var/duration = 2.5 SECONDS
@@ -1019,7 +1019,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "blade_burst"
-	invocation = "blade burst."
+	invocation = "Cut them down."
 	invocation_type = "whisper"
 	var/delay = 7
 	var/damage = 45
@@ -1060,7 +1060,7 @@
 	dropmessage = "I release my arcyne focus."
 	school = "abjuration"
 	charge_max = 30 SECONDS
-	invocation = "Nondetection."
+	invocation = "Shroud their vision."
 	invocation_type = "whisper"
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
@@ -1178,7 +1178,7 @@
 	no_early_release = TRUE
 	movement_interrupt = TRUE
 	charging_slowdown = 2
-	invocation = "featherfall."
+	invocation = "Land safely."
 	invocation_type = "whisper"
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
@@ -1207,7 +1207,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	charging_slowdown = 2
-	invocation = "haste!"
+	invocation = "Quickened step!"
 	invocation_type = "shout"
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane


### PR DESCRIPTION
## About The Pull Request

Changes many instances of placeholder "scream the spell name" incantations to something slightly more thematic.
Eldritch Healing's incantation, on top of being altered, is now whispered like other healing magic so you aren't repeatedly screaming the same phrase in the infirmary like a lunatic.
Also adds default case for Eldritch Curse while I was there because right now it does nothing when learned via scroll.
Blood Bolt and Lightning Bolt have the same incantation in this PR but they might as well be the same spell anyway so I think it's fine.

This does not touch divine magic. I also didn't bother with a few obscure arcane spells because I couldn't think of an incantation better than the actual spell name. All _commonly-used_ arcane spells have been altered, unless they already had a sensible incantation or no incantation at all.

## Why It's Good For The Game

Screaming "fireball" repeatedly is pretty LRP. I kept it specifically for Eldritch Blast because it's a more well-accepted D&D meme. Also hard to make an incantation that would work with every possible warlock patron _and_ non-warlock wizards learning it.

Also, new incantations for Booming Blade and Lightning Lure (the latter is much more important) tell victims what to do to not die to them. Doesn't make the best incantation necessarily but should help with player confusion on a common, powerful spell.