### PR TITLE
Turns Adventurer into an available starter class for new players. (Req PQ = 0)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 
 	display_order = JDO_ADVENTURER
 	show_in_credits = TRUE
-	min_pq = 4
+	min_pq = 0
 	max_pq = null
 
 	advclass_cat_rolls = list(CTAG_ADVENTURER = 30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

What the title says. Adventurer Class now becomes an starter class for new players.

## Why It's Good For The Game

By popular demand and because we are under a severe crisis of dead/lowpop, please reduce the required PQ for Adventurer to 0. I'm aware it has been left like this because DK staff preffered to give less griefing/exploit access to new bad faith players instead of individually punishing them for such.

Right now PQ is very hard to obtain without active players to commend unless if something eye-catching is done to gain some pop back.  (Like the maintainers/reviewers not abandoning this repo for example.)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Required PQ to play Adventurer has been set to zero.

/:cl:

<!-- The Changelog is not currently displayed in the game client, but this may change in the future. For this reason, the cl is identical in format to TGStation's listing. -->
