### PR TITLE
ups the time thresholds for player rotting

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -51,7 +51,7 @@
 		qdel(src)
 		return
 	
-	if(amount > 4 MINUTES)
+	if(amount > 10 MINUTES) //screw it we're just making it over twice the wait
 		if(is_zombie)
 			var/datum/antagonist/zombie/Z = C.mind.has_antag_datum(/datum/antagonist/zombie)
 			if(Z && !Z.has_turned && !Z.revived && C.stat == DEAD)
@@ -63,13 +63,13 @@
 	for(var/obj/item/bodypart/B in C.bodyparts)
 		if(!B.skeletonized && B.is_organic_limb())
 			if(!B.rotted)
-				if(amount > 10 MINUTES)
+				if(amount > 20 MINUTES)
 					B.rotted = TRUE
 					findonerotten = TRUE
 					shouldupdate = TRUE
 					C.change_stat("constitution", -8, "rottenlimbs")
 			else
-				if(amount > 25 MINUTES)
+				if(amount > 30 MINUTES)
 					if(!is_zombie)
 						if(C.dna && C.dna.species)
 							C.dna.species.species_traits |= NOBLOOD
@@ -77,7 +77,7 @@
 						shouldupdate = TRUE
 				else
 					findonerotten = TRUE
-		if(amount > 35 MINUTES)
+		if(amount > 40 MINUTES)
 			if(!is_zombie)
 				if(B.skeletonized)
 					if(!B.owner.client) //so cliented mfers dont get dusted.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Increases the thresholds for players turning into zombies from 4 to 10, and increasing each further rot threshold to 10 more minutes than the last.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gives more time to resurrect through surgery, without removing zombification outright. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: rebalanced something
code: changed some code
/:cl:

<!-- The Changelog is not currently displayed in the game client, but this may change in the future. For this reason, the cl is identical in format to TGStation's listing. -->
