### PR TITLE
Fixes lewdai problems, adds endowed genitals to normal selection, and changes a few lines of goblin code for qol.

### DIFF
--- a/code/_globalvars/customization/organ_customization.dm
+++ b/code/_globalvars/customization/organ_customization.dm
@@ -81,6 +81,7 @@ GLOBAL_LIST_INIT(named_butt_sizes, list(
 	"small" = 1,
 	"medium" = 2,
 	"large" = 3,
+	"massive" = 4,
 ))
 
 //unselectables included.

--- a/code/_globalvars/customization/organ_customization.dm
+++ b/code/_globalvars/customization/organ_customization.dm
@@ -2,6 +2,8 @@ GLOBAL_LIST_INIT(named_penis_sizes, list(
 	"small" = 1,
 	"average" = 2,
 	"large" = 3,
+	"massive" = 4,
+	"enormous" = 5,
 ))
 
 //unselectables included.
@@ -18,6 +20,8 @@ GLOBAL_LIST_INIT(named_ball_sizes, list(
 	"small" = 1,
 	"average" = 2,
 	"large" = 3,
+	"massive" = 4,
+	"enormous" = 5,
 ))
 
 //unselectables included.
@@ -45,6 +49,9 @@ GLOBAL_LIST_INIT(named_breast_sizes, list(
 	"titanic" = 11,
 	"gargantuan" = 12,
 	"colossal" = 13,
+	"unbelieveably big" = 14,
+	"godly big" = 15,
+	"ungodly big" = 16,
 ))
 
 //unselectables included.
@@ -82,6 +89,7 @@ GLOBAL_LIST_INIT(named_butt_sizes, list(
 	"medium" = 2,
 	"large" = 3,
 	"massive" = 4,
+	"enormous" = 5,
 ))
 
 //unselectables included.

--- a/code/_globalvars/customization/organ_customization.dm
+++ b/code/_globalvars/customization/organ_customization.dm
@@ -2,8 +2,6 @@ GLOBAL_LIST_INIT(named_penis_sizes, list(
 	"small" = 1,
 	"average" = 2,
 	"large" = 3,
-	"massive" = 4,
-	"enormous" = 5,
 ))
 
 //unselectables included.
@@ -20,8 +18,6 @@ GLOBAL_LIST_INIT(named_ball_sizes, list(
 	"small" = 1,
 	"average" = 2,
 	"large" = 3,
-	"massive" = 4,
-	"enormous" = 5,
 ))
 
 //unselectables included.
@@ -49,9 +45,6 @@ GLOBAL_LIST_INIT(named_breast_sizes, list(
 	"titanic" = 11,
 	"gargantuan" = 12,
 	"colossal" = 13,
-	"unbelieveably big" = 14,
-	"godly big" = 15,
-	"ungodly big" = 16,
 ))
 
 //unselectables included.
@@ -88,8 +81,6 @@ GLOBAL_LIST_INIT(named_butt_sizes, list(
 	"small" = 1,
 	"medium" = 2,
 	"large" = 3,
-	"massive" = 4,
-	"enormous" = 5,
 ))
 
 //unselectables included.

--- a/code/modules/client/customizer/customizers/organ/genitals.dm
+++ b/code/modules/client/customizer/customizers/organ/genitals.dm
@@ -19,7 +19,7 @@
 /datum/customizer_choice/organ/penis/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/penis/penis_entry = entry
-	penis_entry.organ_size = sanitize_integer(penis_entry.organ_size, MIN_PENIS_SIZE, TOTAL_PENIS_SIZE, DEFAULT_PENIS_SIZE) //change MAX to TOTAL to let players use large genitals but not human npcs
+	penis_entry.organ_size = sanitize_integer(penis_entry.organ_size, MIN_PENIS_SIZE, MAX_PENIS_SIZE, DEFAULT_PENIS_SIZE)
 
 /datum/customizer_choice/organ/penis/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -41,7 +41,7 @@
 			if(isnull(named_size))
 				return
 			var/new_size = GLOB.named_penis_sizes[named_size]
-			penis_entry.organ_size = sanitize_integer(new_size, MIN_PENIS_SIZE, TOTAL_PENIS_SIZE, DEFAULT_PENIS_SIZE)
+			penis_entry.organ_size = sanitize_integer(new_size, MIN_PENIS_SIZE, MAX_PENIS_SIZE, DEFAULT_PENIS_SIZE)
 
 /datum/customizer_entry/organ/penis
 	var/organ_size = DEFAULT_PENIS_SIZE
@@ -185,7 +185,7 @@
 /datum/customizer_choice/organ/testicles/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/testicles/testicles_entry = entry
-	testicles_entry.organ_size = sanitize_integer(testicles_entry.organ_size, MIN_TESTICLES_SIZE, TOTAL_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
+	testicles_entry.organ_size = sanitize_integer(testicles_entry.organ_size, MIN_TESTICLES_SIZE, MAX_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
 
 /datum/customizer_choice/organ/testicles/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -212,7 +212,7 @@
 				if(isnull(named_size))
 					return
 				var/new_size = GLOB.named_ball_sizes[named_size]
-				testicles_entry.organ_size = sanitize_integer(new_size, MIN_TESTICLES_SIZE, TOTAL_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
+				testicles_entry.organ_size = sanitize_integer(new_size, MIN_TESTICLES_SIZE, MAX_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
 			if("virile")
 				testicles_entry.virility = !testicles_entry.virility
 /datum/customizer/organ/testicles/external
@@ -270,7 +270,7 @@
 /datum/customizer_choice/organ/breasts/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/breasts/breasts_entry = entry
-	breasts_entry.organ_size = sanitize_integer(breasts_entry.organ_size, MIN_BREASTS_SIZE, TOTAL_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
+	breasts_entry.organ_size = sanitize_integer(breasts_entry.organ_size, MIN_BREASTS_SIZE, MAX_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
 
 /datum/customizer_choice/organ/breasts/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -294,7 +294,7 @@
 			if(isnull(named_size))
 				return
 			var/new_size = GLOB.named_breast_sizes[named_size]
-			breasts_entry.organ_size = sanitize_integer(new_size, MIN_BREASTS_SIZE, TOTAL_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
+			breasts_entry.organ_size = sanitize_integer(new_size, MIN_BREASTS_SIZE, MAX_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
 		if("refilling")
 			breasts_entry.refilling = !breasts_entry.refilling
 
@@ -342,7 +342,7 @@
 /datum/customizer_choice/organ/belly/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/belly/belly_entry = entry
-	belly_entry.organ_size = sanitize_integer(belly_entry.organ_size, MIN_BELLY_SIZE, MAX_BELLY_SIZE, DEFAULT_BELLY_SIZE) //TOTAL_BELLY_SIZE doesn't exist; just use this
+	belly_entry.organ_size = sanitize_integer(belly_entry.organ_size, MIN_BELLY_SIZE, MAX_BELLY_SIZE, DEFAULT_BELLY_SIZE)
 
 /datum/customizer_choice/organ/belly/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -502,7 +502,7 @@
 /datum/customizer_choice/organ/butt/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/butt/butt_entry = entry
-	butt_entry.organ_size = sanitize_integer(butt_entry.organ_size, MIN_BUTT_SIZE, TOTAL_BUTT_SIZE, DEFAULT_BUTT_SIZE)
+	butt_entry.organ_size = sanitize_integer(butt_entry.organ_size, MIN_BUTT_SIZE, MAX_BUTT_SIZE, DEFAULT_BUTT_SIZE)
 
 /datum/customizer_choice/organ/butt/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -524,7 +524,7 @@
 			if(isnull(named_size))
 				return
 			var/new_size = GLOB.named_butt_sizes[named_size]
-			butt_entry.organ_size = sanitize_integer(new_size, MIN_BUTT_SIZE, TOTAL_BUTT_SIZE, DEFAULT_BUTT_SIZE)
+			butt_entry.organ_size = sanitize_integer(new_size, MIN_BUTT_SIZE, MAX_BUTT_SIZE, DEFAULT_BUTT_SIZE)
 
 /datum/customizer/organ/butt/human
 	customizer_choices = list(/datum/customizer_choice/organ/butt/human)

--- a/code/modules/client/customizer/customizers/organ/genitals.dm
+++ b/code/modules/client/customizer/customizers/organ/genitals.dm
@@ -19,7 +19,7 @@
 /datum/customizer_choice/organ/penis/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/penis/penis_entry = entry
-	penis_entry.organ_size = sanitize_integer(penis_entry.organ_size, MIN_PENIS_SIZE, MAX_PENIS_SIZE, DEFAULT_PENIS_SIZE)
+	penis_entry.organ_size = sanitize_integer(penis_entry.organ_size, MIN_PENIS_SIZE, TOTAL_PENIS_SIZE, DEFAULT_PENIS_SIZE) //change MAX to TOTAL to let players use large genitals but not human npcs
 
 /datum/customizer_choice/organ/penis/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -41,7 +41,7 @@
 			if(isnull(named_size))
 				return
 			var/new_size = GLOB.named_penis_sizes[named_size]
-			penis_entry.organ_size = sanitize_integer(new_size, MIN_PENIS_SIZE, MAX_PENIS_SIZE, DEFAULT_PENIS_SIZE)
+			penis_entry.organ_size = sanitize_integer(new_size, MIN_PENIS_SIZE, TOTAL_PENIS_SIZE, DEFAULT_PENIS_SIZE)
 
 /datum/customizer_entry/organ/penis
 	var/organ_size = DEFAULT_PENIS_SIZE
@@ -65,35 +65,35 @@
 
 /datum/customizer/organ/penis/canine
 	customizer_choices = list(
-		/datum/customizer_choice/organ/penis/human_anthro,
 		/datum/customizer_choice/organ/penis/knotted,
+		/datum/customizer_choice/organ/penis/human_anthro,
 		)
 
 /datum/customizer/organ/penis/feline
 	customizer_choices = list(
-		/datum/customizer_choice/organ/penis/human_anthro,
 		/datum/customizer_choice/organ/penis/barbed,
 		/datum/customizer_choice/organ/penis/barbed_knotted,
+		/datum/customizer_choice/organ/penis/human_anthro,
 		)
 
 /datum/customizer/organ/penis/lizard
 	customizer_choices = list(
-		/datum/customizer_choice/organ/penis/human_anthro,
 		/datum/customizer_choice/organ/penis/tapered,
 		/datum/customizer_choice/organ/penis/tapered_double,
 		/datum/customizer_choice/organ/penis/tapered_double_knot,
+		/datum/customizer_choice/organ/penis/human_anthro,
 		)
 
 /datum/customizer/organ/penis/equine
 	customizer_choices = list(
-		/datum/customizer_choice/organ/penis/human_anthro,
 		/datum/customizer_choice/organ/penis/equine,
+		/datum/customizer_choice/organ/penis/human_anthro,
 		)
 
 /datum/customizer/organ/penis/knotted
 	customizer_choices = list(
-		/datum/customizer_choice/organ/penis/human_anthro,
 		/datum/customizer_choice/organ/penis/knotted,
+		/datum/customizer_choice/organ/penis/human_anthro,
 		)
 
 /datum/customizer_choice/organ/penis/human
@@ -111,129 +111,57 @@
 /datum/customizer_choice/organ/penis/knotted
 	name = "Knotted Penis"
 	organ_type = /obj/item/organ/penis/knotted
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/human,
-		/datum/sprite_accessory/penis/thick,
-		/datum/sprite_accessory/penis/knotted,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/knotted)
 
 /datum/customizer_choice/organ/penis/equine
 	name = "Equine Penis"
 	organ_type = /obj/item/organ/penis/equine
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/flared,
-		/datum/sprite_accessory/penis/barbknot,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/flared)
 
 /datum/customizer_choice/organ/penis/tapered_mammal
 	name = "Tapered Penis (Mammal)"
 	organ_type = /obj/item/organ/penis/tapered_mammal
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/tapered_mammal,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/tapered_mammal)
 
 /datum/customizer_choice/organ/penis/tapered
 	name = "Tapered Penis"
 	organ_type = /obj/item/organ/penis/tapered
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/tapered,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/tapered)
 
 /datum/customizer_choice/organ/penis/tapered_double
 	name = "Hemi Tapered Penis"
 	organ_type = /obj/item/organ/penis/tapered
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/hemi,
-		/datum/sprite_accessory/penis/hemiknot,
-		/datum/sprite_accessory/penis/tentacle,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/hemi)
 
 /datum/customizer_choice/organ/penis/tapered_double_knot
 	name = "Knotted Hemi Tapered Penis"
 	organ_type = /obj/item/organ/penis/tapered
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/hemiknot,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/hemiknot)
 
 /datum/customizer_choice/organ/penis/barbed
 	name = "Barbed Penis"
 	organ_type = /obj/item/organ/penis/barbed
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/human,
-		/datum/sprite_accessory/penis/knotted,
-		/datum/sprite_accessory/penis/barbknot,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/thick)
 
 /datum/customizer_choice/organ/penis/barbed_knotted
 	name = "Barbed Knotted Penis"
 	organ_type = /obj/item/organ/penis/barbed_knotted
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/barbknot,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/barbknot)
 
 /datum/customizer_choice/organ/penis/tentacle
 	name = "Tentacle Penis"
 	organ_type = /obj/item/organ/penis/tentacle
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/tapered,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/tapered)
 
 /datum/customizer_choice/organ/penis/tapered_double
 	name = "Hemi Tapered Penis"
 	organ_type = /obj/item/organ/penis/tapered
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/hemi,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/hemi)
 
 /datum/customizer_choice/organ/penis/tapered_double_knot
 	name = "Knotted Hemi Tapered Penis"
 	organ_type = /obj/item/organ/penis/tapered
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/hemiknot,
-		/datum/sprite_accessory/penis/tentacle,
-		)
-
-/datum/customizer_choice/organ/penis/barbed
-	name = "Barbed Penis"
-	organ_type = /obj/item/organ/penis/barbed
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/barbknot,
-		)
-
-/datum/customizer_choice/organ/penis/barbed_knotted
-	name = "Barbed Knotted Penis"
-	organ_type = /obj/item/organ/penis/barbed_knotted
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/barbknot,
-		)
-
-/datum/customizer_choice/organ/penis/tentacle
-	name = "Tentacle Penis"
-	organ_type = /obj/item/organ/penis/tentacle
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/tentacle,
-		)
-
-/datum/customizer_choice/organ/penis/barbed
-	name = "Barbed Penis"
-	organ_type = /obj/item/organ/penis/barbed
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/barbknot,
-		)
-
-/datum/customizer_choice/organ/penis/barbed_knotted
-	name = "Barbed Knotted Penis"
-	organ_type = /obj/item/organ/penis/barbed_knotted
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/barbknot,
-		)
-
-/datum/customizer_choice/organ/penis/tentacle
-	name = "Tentacle Penis"
-	organ_type = /obj/item/organ/penis/tentacle
-	sprite_accessories = list(
-		/datum/sprite_accessory/penis/tentacle,
-		)
+	sprite_accessories = list(/datum/sprite_accessory/penis/hemiknot)
 
 /datum/customizer/organ/testicles
 	abstract_type = /datum/customizer/organ/testicles
@@ -257,7 +185,7 @@
 /datum/customizer_choice/organ/testicles/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/testicles/testicles_entry = entry
-	testicles_entry.organ_size = sanitize_integer(testicles_entry.organ_size, MIN_TESTICLES_SIZE, MAX_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
+	testicles_entry.organ_size = sanitize_integer(testicles_entry.organ_size, MIN_TESTICLES_SIZE, TOTAL_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
 
 /datum/customizer_choice/organ/testicles/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -284,7 +212,7 @@
 				if(isnull(named_size))
 					return
 				var/new_size = GLOB.named_ball_sizes[named_size]
-				testicles_entry.organ_size = sanitize_integer(new_size, MIN_TESTICLES_SIZE, MAX_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
+				testicles_entry.organ_size = sanitize_integer(new_size, MIN_TESTICLES_SIZE, TOTAL_TESTICLES_SIZE, DEFAULT_TESTICLES_SIZE)
 			if("virile")
 				testicles_entry.virility = !testicles_entry.virility
 /datum/customizer/organ/testicles/external
@@ -342,7 +270,7 @@
 /datum/customizer_choice/organ/breasts/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/breasts/breasts_entry = entry
-	breasts_entry.organ_size = sanitize_integer(breasts_entry.organ_size, MIN_BREASTS_SIZE, MAX_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
+	breasts_entry.organ_size = sanitize_integer(breasts_entry.organ_size, MIN_BREASTS_SIZE, TOTAL_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
 
 /datum/customizer_choice/organ/breasts/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -366,7 +294,7 @@
 			if(isnull(named_size))
 				return
 			var/new_size = GLOB.named_breast_sizes[named_size]
-			breasts_entry.organ_size = sanitize_integer(new_size, MIN_BREASTS_SIZE, MAX_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
+			breasts_entry.organ_size = sanitize_integer(new_size, MIN_BREASTS_SIZE, TOTAL_BREASTS_SIZE, DEFAULT_BREASTS_SIZE)
 		if("refilling")
 			breasts_entry.refilling = !breasts_entry.refilling
 
@@ -414,7 +342,7 @@
 /datum/customizer_choice/organ/belly/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/belly/belly_entry = entry
-	belly_entry.organ_size = sanitize_integer(belly_entry.organ_size, MIN_BELLY_SIZE, MAX_BELLY_SIZE, DEFAULT_BELLY_SIZE)
+	belly_entry.organ_size = sanitize_integer(belly_entry.organ_size, MIN_BELLY_SIZE, MAX_BELLY_SIZE, DEFAULT_BELLY_SIZE) //TOTAL_BELLY_SIZE doesn't exist; just use this
 
 /datum/customizer_choice/organ/belly/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -574,7 +502,7 @@
 /datum/customizer_choice/organ/butt/validate_entry(datum/preferences/prefs, datum/customizer_entry/entry)
 	..()
 	var/datum/customizer_entry/organ/butt/butt_entry = entry
-	butt_entry.organ_size = sanitize_integer(butt_entry.organ_size, MIN_BUTT_SIZE, MAX_BUTT_SIZE, DEFAULT_BUTT_SIZE)
+	butt_entry.organ_size = sanitize_integer(butt_entry.organ_size, MIN_BUTT_SIZE, TOTAL_BUTT_SIZE, DEFAULT_BUTT_SIZE)
 
 /datum/customizer_choice/organ/butt/imprint_organ_dna(datum/organ_dna/organ_dna, datum/customizer_entry/entry, datum/preferences/prefs)
 	..()
@@ -596,7 +524,7 @@
 			if(isnull(named_size))
 				return
 			var/new_size = GLOB.named_butt_sizes[named_size]
-			butt_entry.organ_size = sanitize_integer(new_size, MIN_BUTT_SIZE, MAX_BUTT_SIZE, DEFAULT_BUTT_SIZE)
+			butt_entry.organ_size = sanitize_integer(new_size, MIN_BUTT_SIZE, TOTAL_BUTT_SIZE, DEFAULT_BUTT_SIZE)
 
 /datum/customizer/organ/butt/human
 	customizer_choices = list(/datum/customizer_choice/organ/butt/human)

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -15,7 +15,9 @@
 	erpable = TRUE
 	hornychance = 50
 	//If someone ends up writing custom messages for goblins, lewd talk could be used ig -vide
-	//lewd_talk = TRUE
+	lewd_talk = TRUE //lets the lewdai advert their horniness.
+	male_lewdtalk = list("") //add dialogue at some point. With this, gobs won't say anything but will physically show interest
+	female_lewdtalk = list("")
 	//skin color is "e8b59b"
 	show_genitals = TRUE  //would be good but colors just wont work.
 	skin_tone = "e8b59b"
@@ -579,6 +581,8 @@
 		return
 	if(gobs >= (maxgobs+1))
 		to_chat(user, span_danger("Too many Gobs."))
+		return
+	if(alert("Are you sure you want to become an invading goblin? You may not be able to return to your body.",,"Yes","No")!="Yes")
 		return
 	gobs++
 	var/mob/living/carbon/human/species/goblin/npc/N = new (get_turf(src))

--- a/modular_stonehedge/code/lewdai/lewdai.dm
+++ b/modular_stonehedge/code/lewdai/lewdai.dm
@@ -47,7 +47,7 @@
 	if(handcuffed || legcuffed || lying)
 		return
 	if(sexcon && !chasesfuck)
-		for(var/mob/living/carbon/human/fucktarg in oview(aggro_vision_range, 1))
+		for(var/mob/living/carbon/human/fucktarg in oview(aggro_vision_range, src))
 			if(fucktarg == src)
 				continue
 			if(!aggressive && fucktarg.cmode) //skip if the target has cmode on and the mob is not aggressive.
@@ -98,7 +98,7 @@
 		return
 	var/mob/living/carbon/human/L
 	var/list/foundfuckmeat = list()
-	for(var/mob/living/carbon/human/fucktarg in oview(aggro_vision_range, 1))
+	for(var/mob/living/carbon/human/fucktarg in oview(aggro_vision_range, src))
 		if(fucktarg.has_quirk(/datum/quirk/monsterhuntermale) || fucktarg.has_quirk(/datum/quirk/monsterhunterfemale))
 			foundfuckmeat += fucktarg
 		if(foundfuckmeat.len)
@@ -269,7 +269,7 @@
 		seeklewd()
 	if(seekboredom > 25) //give up after a while and go dormant again, this should also help them get unstuck.
 		stoppedfucking(timedout = TRUE)
-	if(chasesfuck) //we are outta here due pain.
+	if(mode == AI_FLEE && chasesfuck) //we are outta here.
 		stoppedfucking(timedout = TRUE)
 
 /mob/living/carbon/human/proc/seeklewd()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The LewdAI code has a small number of errors brought on by recent development. This pull aims to at least squash the ones preventing basic functionality. There's still undoubtedly more to get rid of, but this _should_ allow it to work as originally intended.

The first fix is porting the human mob pathfinding function to rogue simplemobs. The lewd AI code was already calling for it, but because it was never properly set up simplemobs wouldn't approach their targets. The second changes a variable in the oview call for checking for someone to target. It originally had a value of "1" for the origin, so I changed it to "src" like most mob-based oview calls use. Lastly, carbons were being told to time out after only one tick because "retaliate" isn't a valid variable for carbons and was never properly replaced. I've changed it to a check for an AI mode of "fleeing" (mode == AI_FLEE). In addition, a few vars were changed in the goblin code to allow them to at least emote their interest in a player.

In addition, this adds the ability to select all genital organs we currently have sprites for. We still need quad and sextuple breast sprites for the higher ranges, but they didn't even go up to the original limit to begin with anyway.

This was done first by changing the global vars for genitals. This allows for an expanded selection. The second is to change every check for appropriate player genital size to check for TOTAL instead of MAX. Since bellies don't currently have a TOTAL and I don't plan to expand on the sizes, it'll stay at MAX for the time being. Lewd AI still only assigns up to the MAX size for preference reasons.

The last fix was just adding a confirmation message to clicking on a goblin portal as a ghost. Nothing really complex, just an additional if statement.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing the AI sex code has been something people have wanted for a long time. In addition, many have asked for a way to have hyper genitals without the quirks. With this change, it should allow the quirks to work for flags and the examine test while allowing people to have specific hyper organs otherwise. In addition, there's a lot of confusion as to if a goblin is even trying to target someone; a basic setup was added to let them emote it without yelling about a mate. Lastly, some people were complaining that misclicking a goblin portal can cause a round removal, so it was a prudent addition since I was already adding to the goblin code.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed a few things
qol: made something easier to use
code: changed some code
refactor: refactored some code
/:cl:

<!-- The Changelog is not currently displayed in the game client, but this may change in the future. For this reason, the cl is identical in format to TGStation's listing. -->
