### PR TITLE
Ports some statpacks from Azure

### DIFF
--- a/modular_hearthstone/statpacks/agile.dm
+++ b/modular_hearthstone/statpacks/agile.dm
@@ -29,3 +29,13 @@
 	name = "Wary"
 	desc = "Eyes forward, ever and always. A careful course has always seen you through... so far."
 	stat_array = list(STAT_STRENGTH = -1, STAT_PERCEPTION = 2, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 1, STAT_SPEED = -1)
+
+/datum/statpack/agile/dextrous
+	name = "Dextrous"
+	desc = "You see. You dash. You spring. You dodge. Can you keep it up?"
+	stat_array = list(STAT_SPEED = 2, STAT_PERCEPTION = 1, STAT_CONSTITUTION = -2, STAT_INTELLIGENCE = -1)
+
+/datum/statpack/agile/deft
+	name = "Deft"
+	desc = "Being quick on the draw has left you weaker when they live past your first strike."
+	stat_array = list(STAT_PERCEPTION = 1, STAT_SPEED = 1, STAT_ENDURANCE = 1, STAT_STRENGTH = -1)

--- a/modular_hearthstone/statpacks/mental.dm
+++ b/modular_hearthstone/statpacks/mental.dm
@@ -23,3 +23,23 @@
 	name = "Adept"
 	desc = "Your will leads the way."
 	stat_array = list(STAT_STRENGTH = -1, STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = -1, STAT_SPEED = 1)
+
+/datum/statpack/mental/aware
+	name = "Aware"
+	desc = "Your keen senses have not led you astray."
+	stat_array = list(STAT_PERCEPTION = 2, STAT_SPEED = 1, STAT_ENDURANCE = -1, STAT_CONSTITUTION = -1)
+
+/datum/statpack/mental/precise
+	name = "Precise"
+	desc = "You've seen it all. You've heard it all. An eye to the horizon, and an ear to the ground, and the right place to strike."
+	stat_array = list(STAT_PERCEPTION = 2, STAT_STRENGTH = 1, STAT_ENDURANCE = -1, STAT_CONSTITUTION = -1)
+
+/datum/statpack/mental/diligent
+	name = "Diligent"
+	desc = "You take your time, but you have a lot of it to spare."
+	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_ENDURANCE = 1, STAT_SPEED = -1)
+
+/datum/statpack/mental/industrious
+	name = "Industrious"
+	desc = "You waste no time. You know enough to get by, and strive towards it."
+	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_SPEED = 1, STAT_CONSTITUTION = -1, STAT_PERCEPTION = -1)

--- a/modular_hearthstone/statpacks/physical.dm
+++ b/modular_hearthstone/statpacks/physical.dm
@@ -23,3 +23,9 @@
 	name = "Toil-hardened"
 	desc = "Your life, hard-lived, has imparted one solitary adage: carry on above all else. And so you endure."
 	stat_array = list(STAT_STRENGTH = -1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1, STAT_CONSTITUTION = 2, STAT_ENDURANCE = 2)
+
+
+/datum/statpack/physical/struggler
+	name = "Struggler"
+	desc = "Lyfe's dealt you a poor hand, so you've opted to simply flip the table instead."
+	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_ENDURANCE = 2, STAT_INTELLIGENCE = -3, STAT_PERCEPTION = -3, STAT_FORTUNE = -2)

--- a/modular_hearthstone/statpacks/wildcard.dm
+++ b/modular_hearthstone/statpacks/wildcard.dm
@@ -13,7 +13,3 @@
 	name = "Frail"
 	desc = "The growing dark limns your vision more with every passing day: your flesh and mind are failing you, and destiny has turned her gaze from you. How will your tale endure such hardship?"
 	stat_array = list(STAT_STRENGTH = -4, STAT_PERCEPTION = -4, STAT_INTELLIGENCE = -4, STAT_CONSTITUTION = -4, STAT_ENDURANCE = -4, STAT_SPEED = -4, STAT_FORTUNE = -4)
-
-/datum/statpack/wildcard/austere
-	name = "Austere"
-	desc = "You've kept your humors balanced, your body honed and mind sharp enough. Fate has left you mostly unchanged, in every way."

--- a/modular_hearthstone/statpacks/wildcard.dm
+++ b/modular_hearthstone/statpacks/wildcard.dm
@@ -13,3 +13,7 @@
 	name = "Frail"
 	desc = "The growing dark limns your vision more with every passing day: your flesh and mind are failing you, and destiny has turned her gaze from you. How will your tale endure such hardship?"
 	stat_array = list(STAT_STRENGTH = -4, STAT_PERCEPTION = -4, STAT_INTELLIGENCE = -4, STAT_CONSTITUTION = -4, STAT_ENDURANCE = -4, STAT_SPEED = -4, STAT_FORTUNE = -4)
+
+/datum/statpack/wildcard/austere
+	name = "Austere"
+	desc = "You've kept your humors balanced, your body honed and mind sharp enough. Fate has left you mostly unchanged, in every way."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Imagine stopping coding just because a rebase is coming.

Ports over the following statpacks (The rest we already had):
 - Aware - 2PER, 1SPD, -1END, -1CON
 - Deft - 1PER, 1SPD, 1END, -1STR
 - Dextrous - 2SPD, 1PER, -2CON, -1INT
 - Diligent - 2INT, 1END, -1SPD
 - Industrious - 2INT, 1SPD, -1CON, -1PER
 - Precise - 2PER, 1STR, -1END, -1CON
 - Struggler - 2STR, 2CON, 2END, -3INT, -3PER, -2FOR

Didn't port Austere (Their no-stats statpack), since we have 'None'
