### PR TITLE
red, yellow, and tundra grass fixes

### DIFF
--- a/code/modules/farming/plough.dm
+++ b/code/modules/farming/plough.dm
@@ -16,7 +16,7 @@
 		user_tries_tilling(pulledby, get_turf(src))
 
 /obj/structure/plough/proc/user_tries_tilling(mob/living/user, turf/location)
-	if(istype(location, /turf/open/floor/rogue/grass))
+	if(istype(location, /turf/open/floor/rogue/grass) || istype(location, /turf/open/floor/rogue/grassred) || istype(location, /turf/open/floor/rogue/grassyel) || istype(location, /turf/open/floor/rogue/grasscold))
 		apply_farming_fatigue(user, 10)
 		playsound(location,'sound/items/dig_shovel.ogg', 100, TRUE)
 		location.ChangeTurf(/turf/open/floor/rogue/dirt, flags = CHANGETURF_INHERIT_AIR)

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -220,7 +220,7 @@
 /obj/item/rogueweapon/hoe/attack_turf(turf/T, mob/living/user)
 	if(user.used_intent.type == /datum/intent/till)
 		user.changeNext_move(CLICK_CD_MELEE)
-		if(istype(T, /turf/open/floor/rogue/grass))
+		if(istype(T, /turf/open/floor/rogue/grass) || istype(T, /turf/open/floor/rogue/grassyel) || istype(T, /turf/open/floor/rogue/grassred) || istype(T, /turf/open/floor/rogue/grasscold))
 			playsound(T,'sound/items/dig_shovel.ogg', 100, TRUE)
 			if (do_after(user, 3 SECONDS, target = src))
 				apply_farming_fatigue(user, 10)

--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -97,7 +97,7 @@
 			playsound(T,'sound/items/empty_shovel.ogg', 100, TRUE)
 			update_icon()
 			return
-		if(istype(T, /turf/open/floor/rogue/grass))
+		if(istype(T, /turf/open/floor/rogue/grass) || istype(T, /turf/open/floor/rogue/grassyel) || istype(T, /turf/open/floor/rogue/grassred) || istype(T, /turf/open/floor/rogue/grasscold))
 			to_chat(user, span_warning("There is grass in the way."))
 			return
 		return

--- a/modular_hearthstone/code/game/objects/effects/track.dm
+++ b/modular_hearthstone/code/game/objects/effects/track.dm
@@ -9,6 +9,15 @@
 
 /turf/open/floor/rogue/grass
 	track_prob = 1
+
+/turf/open/floor/rogue/grassred
+	track_prob = 1
+
+/turf/open/floor/rogue/grassyel
+	track_prob = 1
+
+/turf/open/floor/rogue/grasscold
+	track_prob = 1
 //Probabilities end (albeit mud is handled seperately).
 
 //Analysis levels depending on skillcheck during reveal.
@@ -88,7 +97,7 @@
 	if(!HAS_TRAIT(user, TRAIT_PERFECT_TRACKER))
 		var/diff = 11 //Base Tracking Difficulty
 		diff += tracking_modifier
-		diff += round((world.time - creation_time) / (60 SECONDS), 1) //Gets more difficult to spot the older.
+		diff += round((world.time - creation_time) / (120 SECONDS), 1) //Gets more difficult to spot the older.
 		diff += rand(0, 5) //Entropy.
 
 		var/competence = user.STAPER
@@ -112,7 +121,7 @@
 	if(!HAS_TRAIT(user, TRAIT_PERFECT_TRACKER))
 		var/diff = 11
 		diff += tracking_modifier
-		diff += round((world.time - creation_time) / (60 SECONDS), 1) 
+		diff += round((world.time - creation_time) / (120 SECONDS), 1)
 		var/competence = user.STAPER / 2
 		if(user.mind)
 			competence += 5 * user.mind.get_skill_level(/datum/skill/misc/tracking) //Skill is much more relevant for analysis.
@@ -159,7 +168,7 @@
 		if(SOUTHEAST)
 			facing = "southeast"
 	real_image = image(icon, src, real_icon_state, ABOVE_OPEN_TURF_LAYER, track_source.dir) //Recreate image with correct dir.
-	deletion_timer = addtimer(CALLBACK(src, PROC_REF(track_expire)), 15 MINUTES, TIMER_STOPPABLE) //Tracks naturally expire after 15 minutes (although at that point their DC is pretty high anyways.)
+	deletion_timer = addtimer(CALLBACK(src, PROC_REF(track_expire)), 30 MINUTES, TIMER_STOPPABLE) //Tracks naturally expire after 30 minutes (although at that point their DC is pretty high anyways.)
 
 ///Adds a new person to the list of people who can see this track.
 /obj/effect/track/proc/add_knower(mob/living/tracker, competence = 1)
@@ -266,7 +275,7 @@
 		return //Guh?
 	if(!(movement_type & GROUND) || (movement_type & (FLOATING|FLYING))) //For some reason some mobs have both ground and flying at once.
 		return
-	var/probability = round(track_creation_prob(new_turf), 0.1) 
+	var/probability = round(track_creation_prob(new_turf), 0.1)
 	if(!probability)
 		return
 	if(!prob(probability))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
When the new variants of grass were added to the code, they were added as additional types of rogue floor, rather than as subtypes of the existing grass turf. Rather than change the types into subtypes, which would require a lot of map fixes, I opted to patch a handful of issues caused by this implementation. I have also doubled the duration that tracks will linger for.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Tracks will now linger for twice as long; difficulty scaling is adjusted to compensate for this.
fix: Hoes and ploughs can now till the new grass variants. Shovels will treat them the same as regular grass for feedback purposes. Seeds can now form soil piles on them.
fix: Players can now leave tracks on the new grass variants.
/:cl:

<!-- The Changelog is not currently displayed in the game client, but this may change in the future. For this reason, the cl is identical in format to TGStation's listing. -->
